### PR TITLE
(PE-2078) Add support for multi-form service bodies

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -128,9 +128,10 @@
             datastore (atom {})]
         {:get (fn [key]       (log \"Getting...\") (get @datastore key))
          :put (fn [key value] (log \"Putting...\") (swap! datastore assoc key value))}))"
-  ([svc-name io-map body]
-    `(defservice ~svc-name "" ~io-map ~body))
-  ([svc-name svc-doc io-map body]
+  [svc-name & forms]
+  (let [[svc-doc io-map body] (if (string? (first forms))
+                                  [(first forms) (second forms) (nthrest forms 2)]
+                                  ["" (first forms) (rest forms)])]
     (let [binding-form (io->fnk-binding-form io-map)]
       `(defn ~svc-name
          ~svc-doc
@@ -138,4 +139,4 @@
          {~(keyword svc-name)
             (fnk
               ~binding-form
-              ~body)}))))
+              ~@body)}))))

--- a/test/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/puppetlabs/trapperkeeper/core_test.clj
@@ -160,7 +160,6 @@ This is not a legit line.
             (trapperkeeper/parse-cli-args! ["--invalid-argument"])))))
 
 (deftest defservice-macro
-
   (defservice logging-service
     {:depends  []
      :provides [log]}
@@ -170,6 +169,9 @@ This is not a legit line.
     "My simple service"
     {:depends  [[:logging-service log]]
      :provides [hello]}
+    ;; this line is really just here to test support for multi-form service
+    ;; bodies
+    (log "Calling our test log function!")
     (let [state "world"]
       {:hello (fn [] state)}))
 


### PR DESCRIPTION
Prior to this commit, the `defservice` macro did not support
service bodies that contained more than one form.  This commit
adds support for multi-form service bodies.
