### PR TITLE
Improved error handling

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -171,9 +171,10 @@
   (try
     (graph-fn {})
     (catch RuntimeException e
-      (let [match (re-matches #"^Key (:.*) not found in null$" (.getMessage e))]
-        (if match
-          (throw (RuntimeException. (format "Service '%s' not found" (second match))))
+      (if-let [match (re-matches #"^Key (:.*) not found in null$" (.getMessage e))]
+        (throw (RuntimeException. (format "Service '%s' not found" (second match))))
+        (if-let [match (re-matches #"^Key :(.*) not found in .*$" (.getMessage e))]
+          (throw (RuntimeException. (format "Service function '%s' not found" (second match))))
           (throw e))))))
 
 (defn bootstrap*

--- a/test/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/puppetlabs/trapperkeeper/core_test.clj
@@ -258,4 +258,25 @@ This is not a legit line.
                                    {:unused #()})]
       (is (thrown-with-msg?
             RuntimeException #"Service function 'bar' not found"
-            (trapperkeeper/bootstrap* [(test-service) (broken-service)]))))))
+            (trapperkeeper/bootstrap* [(test-service) (broken-service)]))))
+
+    (let [test-service    (service :test-service
+                                   {:depends  []
+                                    :provides [foo bar]}
+                                   {:foo #()})
+          broken-service  (service :broken-service
+                                   {:depends  [[:test-service foo bar]]
+                                    :provides [unused]}
+                                   {:unused #()})]
+      (is (thrown-with-msg?
+            RuntimeException #"Service function 'bar' not found"
+            (trapperkeeper/bootstrap* [(test-service) (broken-service)]))))
+
+    (let [broken-service  (service :broken-service
+                                   {:depends  []
+                                    :provides [unused]}
+                                   (throw (RuntimeException. "This shouldn't match the regexs"))
+                                   {:unused #()})]
+      (is (thrown-with-msg?
+            RuntimeException #"This shouldn't match the regexs"
+            (trapperkeeper/bootstrap* [(broken-service)]))))))


### PR DESCRIPTION
The exception that Graph throws is different depending on how it's provided and depended on, which Kevin discovered on Friday.  This adds another regex to handle the different exception message.
