### PR TITLE
Silence logs during tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [puppetlabs/kitchensink "0.2.0"]
-                 [clj-http "0.5.3" :scope "test"]
                  [org.eclipse.jetty/jetty-server "7.6.1.v20120215"]
                  [ring/ring-servlet "1.1.8"]
 
@@ -29,4 +28,6 @@
   :classifiers [["test" :testutils]]
 
   :profiles {:dev {:test-paths ["test-resources"]}
+             :test {:dependencies [[clj-http "0.5.3"]
+                                   [org.slf4j/slf4j-log4j12 "1.7.5"]]}
              :testutils {:source-paths ^:replace ["test"]}})

--- a/test-resources/another-log4j.properties
+++ b/test-resources/another-log4j.properties
@@ -1,1 +1,0 @@
-log4j.rootLogger=WARN

--- a/test-resources/log4j.properties
+++ b/test-resources/log4j.properties
@@ -1,1 +1,8 @@
-log4j.rootLogger=DEBUG
+log4j.rootLogger=ERROR, A1
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d %-5p [%c{2}] %m%n
+
+# Silence particularly noisy packages
+log4j.logger.org.eclipse.jetty.server=WARN
+log4j.logger.puppetlabs.trapperkeeper.services.jetty.jetty-config=ERROR

--- a/test-resources/logging/log4j-debug.properties
+++ b/test-resources/logging/log4j-debug.properties
@@ -1,0 +1,2 @@
+# This is only used as a test file, not for actually configuring logging during tests
+log4j.rootLogger=DEBUG

--- a/test-resources/logging/log4j-warn.properties
+++ b/test-resources/logging/log4j-warn.properties
@@ -1,0 +1,2 @@
+# This is only used as a test file, not for actually configuring logging during tests
+log4j.rootLogger=WARN

--- a/test/puppetlabs/trapperkeeper/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/logging_test.clj
@@ -17,12 +17,12 @@
 
 (deftest test-logging-configuration
   (testing "Calling `configure-logging!` with a log4j.properties file"
-    (configure-logging! "./test-resources/log4j.properties")
+    (configure-logging! "./test-resources/logging/log4j-debug.properties")
     (is (= (Level/DEBUG) (.getLevel (Logger/getRootLogger)))))
 
   (testing "Calling `configure-logging!` with another log4j.properties file
             in case the default logging level is DEBUG"
-    (configure-logging! "./test-resources/another-log4j.properties")
+    (configure-logging! "./test-resources/logging/log4j-warn.properties")
     (is (= (Level/WARN) (.getLevel (Logger/getRootLogger)))))
 
   (testing "a logging config file isn't required"


### PR DESCRIPTION
This commit introduces a log4j.properties file that is intended
for configuring logging during tests. The existing one was used
as a test file and not specifically for configuring logging, so
it has moved into test-resources/logging.
