### PR TITLE
Remove puppet and puppetdb-specific strings

### DIFF
--- a/src/puppetlabs/trapperkeeper/logging.clj
+++ b/src/puppetlabs/trapperkeeper/logging.clj
@@ -21,7 +21,7 @@
 
 (defn create-console-appender
   "Instantiates and returns a logging appender configured to write to
-  the console, using the standard puppetdb logging configuration.
+  the console, using the standard logging configuration.
 
   `level` is an optional argument (of type `org.apache.log4j.Level`)
   indicating the logging threshold for the new appender.  Defaults

--- a/test-resources/config/jetty/jetty.ini
+++ b/test-resources/config/jetty/jetty.ini
@@ -6,9 +6,7 @@
 port = 8080
 
 
-# The following are SSL specific settings. They can be configured
-# automatically with the tool `puppetdb ssl-setup`, which is normally
-# ran during package installation.
+# The following are SSL specific settings.
 
 # The host or IP address to listen on for HTTPS connections
 # ssl-host = <host>


### PR DESCRIPTION
There were some strings (used in log messages, docs, ssl certificate
aliases, etc.) that referred to PuppetDB.  I believe that these
things don't actually have any tight coupling with Puppet or PuppetDB,
so I've changed them to make them more general.

It's possible that we'll need to make the SSL certificate alias
configurable, if PuppetDB is expecting for it to exactly match
the value that it was previously using ("PuppetDB CA"), but
I've not done that yet because I'm not sure whether it's actually
necessary.
