### PR TITLE
Rename :jetty-service to :webserver-service

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/jetty/jetty_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/jetty/jetty_service.clj
@@ -3,11 +3,14 @@
     [puppetlabs.trapperkeeper.services.jetty.jetty-core :as core]
     [puppetlabs.trapperkeeper.core :refer [defservice]]))
 
-(defservice jetty-service
+(defservice webserver-service
   "Provides a Jetty web server as a service"
   {:depends [[:config-service get-in-config]]
    :provides [add-ring-handler join shutdown]}
-  (let [config    (or (get-in-config [:jetty]) {})
+  (let [config    (or (get-in-config [:webserver])
+                      ;; Here for backward compatibility with existing projects
+                      (get-in-config [:jetty])
+                      {})
         webserver (core/start-webserver config)]
     {:add-ring-handler  (partial core/add-ring-handler webserver)
      :join              (partial core/join webserver)

--- a/test-resources/config/jetty/jetty-ssl-jks.ini
+++ b/test-resources/config/jetty/jetty-ssl-jks.ini
@@ -1,4 +1,4 @@
-[jetty]
+[webserver]
   port           = 8080
   ssl-host       = 0.0.0.0
   ssl-port       = 8081

--- a/test-resources/config/jetty/jetty-ssl-pem.ini
+++ b/test-resources/config/jetty/jetty-ssl-pem.ini
@@ -1,4 +1,4 @@
-[jetty]
+[webserver]
   port        = 8080
   ssl-host    = 0.0.0.0
   ssl-port    = 8081

--- a/test-resources/config/jetty/jetty.ini
+++ b/test-resources/config/jetty/jetty.ini
@@ -1,4 +1,4 @@
-[jetty]
+[webserver]
 # Hostname or IP address to listen for clear-text HTTP.  Default is localhost
 # host = <host>
 

--- a/test/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
@@ -6,12 +6,12 @@
 
 (deftest test-jetty-service
   (testing "An example TK app with a jetty service"
-    (let [services         [(jetty-service)]
+    (let [services         [(webserver-service)]
           cli-data         {:config "./test-resources/config/jetty/jetty.ini"}
           tk-app           (bootstrap* services cli-data)
-          add-ring-handler (get-service-fn tk-app :jetty-service :add-ring-handler)
-          join             (get-service-fn tk-app :jetty-service :join)
-          shutdown         (get-service-fn tk-app :jetty-service :shutdown)
+          add-ring-handler (get-service-fn tk-app :webserver-service :add-ring-handler)
+          join             (get-service-fn tk-app :webserver-service :join)
+          shutdown         (get-service-fn tk-app :webserver-service :shutdown)
           body             "Hello World"
           path             "/hello_world"
           ring-handler     (fn [req] {:status 200 :body body})]
@@ -29,10 +29,10 @@
   (testing "SSL initialization is supported for both .jks and .pem implementations"
     (doseq [config ["./test-resources/config/jetty/jetty-ssl-jks.ini"
                     "./test-resources/config/jetty/jetty-ssl-pem.ini"]]
-      (let [app               (bootstrap* [(jetty-service)] {:config config})
-            add-ring-handler  (get-service-fn app :jetty-service :add-ring-handler)
-            join              (get-service-fn app :jetty-service :join)
-            shutdown          (get-service-fn app :jetty-service :shutdown)
+      (let [app               (bootstrap* [(webserver-service)] {:config config})
+            add-ring-handler  (get-service-fn app :webserver-service :add-ring-handler)
+            join              (get-service-fn app :webserver-service :join)
+            shutdown          (get-service-fn app :webserver-service :shutdown)
             body              "Hi World"
             path              "/hi_world"
             ring-handler      (fn [req] {:status 200 :body body})]


### PR DESCRIPTION
I'd like for external users to never be forced to use the word
'jetty' to refer to our webserver service in any location other
than their bootstrap.cfg file.  This would theoretically give us
the ability to switch to a different webserver implementation
(e.g. netty) while maintaining API compatibility, and then users
would only need to change their bootstrap config and not any
of their code.
