### PR TITLE
Default jetty to port 8080

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/jetty/jetty_config.clj
+++ b/src/puppetlabs/trapperkeeper/services/jetty/jetty_config.clj
@@ -72,8 +72,8 @@
   {:pre  [(map? options)]
    :post [(map? %)
           (missing? % :ssl-key :ssl-cert :ssl-ca-cert)]}
-  (let [initial-config    {:max-threads 50}
-        merged-options    (merge initial-config options)
+  (let [defaults          {:max-threads 50 :port 8080}
+        options           (merge defaults options)
         pem-required-keys [:ssl-key :ssl-cert :ssl-ca-cert]
         pem-config        (select-keys options pem-required-keys)]
     (-> (condp = (count pem-config)
@@ -83,4 +83,4 @@
                    (format "Found SSL config options: %s; If configuring SSL from PEM files, you must provide all of the following options: %s"
                      (keys pem-config) pem-required-keys))))
       (assoc :client-auth :need)
-      (assoc :max-threads (jetty7-minimum-threads (:max-threads merged-options))))))
+      (assoc :max-threads (jetty7-minimum-threads (:max-threads options))))))

--- a/src/puppetlabs/trapperkeeper/services/jetty/jetty_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/jetty/jetty_core.clj
@@ -131,7 +131,7 @@
     "Start a Jetty webserver according to the supplied options:
 
     :configurator - a function called with the Jetty Server instance
-    :port         - the port to listen on (defaults to 80)
+    :port         - the port to listen on (defaults to 8080)
     :host         - the hostname to listen on
     :join?        - blocks the thread until server ends (defaults to true)
     :ssl?         - allow connections over HTTPS

--- a/test/puppetlabs/trapperkeeper/services/jetty/jetty_config_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/jetty/jetty_config_test.clj
@@ -60,8 +60,8 @@
   (testing "should merge configuration with initial-configs correctly"
     (let [user-config {:truststore "foo"}
           config      (configure-web-server user-config)]
-      (is (= config {:truststore "foo" :max-threads 50 :client-auth :need})))
-    (let [user-config {:max-threads 500 :truststore "foo"}
+      (is (= config {:truststore "foo" :max-threads 50 :client-auth :need :port 8080})))
+    (let [user-config {:max-threads 500 :truststore "foo" :port 8000}
           config      (configure-web-server user-config)]
-      (is (= config {:truststore "foo" :max-threads 500 :client-auth :need})))))
+      (is (= config {:truststore "foo" :max-threads 500 :client-auth :need :port 8000})))))
 


### PR DESCRIPTION
Prior to this commit the default was port 80; this changes it
to 8080.  Also fixes some minor issues with the way that the
jetty options were being handled with respect to default values.
