### PR TITLE
Fix bug that would allow shutdown to be run twice

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -207,8 +207,9 @@
                                         :wait-for-shutdown  #(deref shutdown-reason)
                                         :shutdown-on-error  shutdown-on-error})]
     (add-shutdown-hook! #(do
-                           (shutdown!)
-                           (deliver shutdown-reason {:type :jvm-shutdown-hook})))
+                           (when-not (realized? shutdown-reason)
+                             (shutdown!)
+                             (deliver shutdown-reason {:type :jvm-shutdown-hook}))))
     (merge (shutdown-service) wrapped-graph)))
 
 (defn request-shutdown!

--- a/src/puppetlabs/trapperkeeper/services/jetty/jetty_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/jetty/jetty_core.clj
@@ -174,4 +174,5 @@
 
 (defn shutdown
   [webserver]
+  (log/info "Shutting down web server.")
   (.stop (:server webserver)))


### PR DESCRIPTION
This commit makes a slight change to the behavior of the shutdown
hook code so that it checks to see if the `shutdown-reason` promise
has been realized before it calls the shutdown logic.

Without this change, in the case where a shutdown was triggered
by a user request or an error, the `run` function would call
the shutdown logic and then the main thread would exit, which
would trigger the JVM shutdown hook, which would then execute
the shutdown code a second time.
