### PR TITLE
Disable JVM shutdown hook registration during tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [puppetlabs/kitchensink "0.2.0"]
+                 [puppetlabs/kitchensink "0.3.0-SNAPSHOT"]
                  [org.eclipse.jetty/jetty-server "7.6.1.v20120215"]
                  [ring/ring-servlet "1.1.8"]
 
@@ -29,7 +29,8 @@
 
   :profiles {:dev {:test-paths ["test-resources"]}
              :test {:dependencies [[clj-http "0.5.3"]
-                                   [org.slf4j/slf4j-log4j12 "1.7.5"]]}
+                                   [org.slf4j/slf4j-log4j12 "1.7.5"]
+                                   [puppetlabs/kitchensink "0.3.0-SNAPSHOT" :classifier "test"]]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   :main puppetlabs.trapperkeeper.main

--- a/test/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/puppetlabs/trapperkeeper/core_test.clj
@@ -10,7 +10,10 @@
             [puppetlabs.trapperkeeper.core :as trapperkeeper :refer [defservice service parse-cli-args!]]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging with-test-logging-debug]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer :all]
-            [puppetlabs.kitchensink.classpath :refer [with-additional-classpath-entries]]))
+            [puppetlabs.kitchensink.classpath :refer [with-additional-classpath-entries]]
+            [puppetlabs.kitchensink.testutils.fixtures :refer [with-no-jvm-shutdown-hooks]]))
+
+(use-fixtures :once with-no-jvm-shutdown-hooks)
 
 (deftest test-bootstrapping
   (testing "Valid bootstrap configurations"

--- a/test/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.jetty.jetty-service-test
   (:require [clojure.test :refer :all]
             [clj-http.client :as http-client]
-            [puppetlabs.trapperkeeper.core :refer [defservice bootstrap* get-service-fn]]
+            [puppetlabs.trapperkeeper.core :refer [bootstrap* get-service-fn]]
             [puppetlabs.trapperkeeper.services.jetty.jetty-service :refer :all]))
 
 (deftest test-jetty-service


### PR DESCRIPTION
NOTE this required a dependency bump on kitchensink 0.3.0-SNAPSHOT
