### PR TITLE
'run' vs. 'runApp' for launching TK

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -320,7 +320,7 @@
         required    [:config]]
     (first (cli! cli-args specs required))))
 
-(defn runApp
+(defn run-app
   "TODO docstring"
   [^TrapperKeeperApp app]
   (let [shutdown-reason (wait-for-shutdown app)]
@@ -338,7 +338,7 @@
   [cli-data]
   (->
     (bootstrap)
-    (runApp)))
+    (run-app)))
 
 (defn main
   [& args]

--- a/test/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/puppetlabs/trapperkeeper/core_test.clj
@@ -236,7 +236,7 @@ This is not a legit line.
                                       :provides [shutdown]}
                                      {:shutdown #(reset! shutdown-called? true)})
           app               (bootstrap-services-with-empty-config [(test-service)])
-          thread            (future (trapperkeeper/runApp app))]
+          thread            (future (trapperkeeper/run-app app))]
       (is (false? @shutdown-called?))
       (trapperkeeper/request-shutdown! app)
       (deref thread)
@@ -251,7 +251,7 @@ This is not a legit line.
                                       :broken-fn (fn [] (future (shutdown-on-error #(throw (RuntimeException. "oops")))))})
           app                (bootstrap-services-with-empty-config [(test-service)])
           broken-fn          (trapperkeeper/get-service-fn app :test-service :broken-fn)
-          main-thread        (future (trapperkeeper/runApp app))]
+          main-thread        (future (trapperkeeper/run-app app))]
       (is (false? @shutdown-called?))
       (broken-fn)
       (is (thrown-with-msg?
@@ -270,7 +270,7 @@ This is not a legit line.
                                                                              #(reset! on-error-fn-called? true)))})
           app                 (bootstrap-services-with-empty-config [(broken-service)])
           broken-fn           (trapperkeeper/get-service-fn app :broken-service :broken-fn)
-          main-thread         (future (trapperkeeper/runApp app))]
+          main-thread         (future (trapperkeeper/run-app app))]
       (is (false? @shutdown-called?))
       (is (false? @on-error-fn-called?))
       (broken-fn)
@@ -289,7 +289,7 @@ This is not a legit line.
           app             (bootstrap-services-with-empty-config [(broken-service)])
           broken-fn       (trapperkeeper/get-service-fn app :broken-service :broken-fn)]
       (with-test-logging
-        (let [main-thread (future (trapperkeeper/runApp app))]
+        (let [main-thread (future (trapperkeeper/run-app app))]
           (broken-fn)
           ;; main will rethrow the "unused" exception as expected
           ;; so we need to prevent that from failing the test


### PR DESCRIPTION
- 'run' is expected to be the common use-case
- 'runApp' is useful for testing

The result of this is that consumers don't have to call `bootstrap` and then `run` - they can just call `run`
