### PR TITLE
(PE-2296) fix warning when running 'lein jar'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,8 @@
              :test {:dependencies [[clj-http "0.5.3"]
                                    [org.slf4j/slf4j-log4j12 "1.7.5"]
                                    [puppetlabs/kitchensink "0.3.1-SNAPSHOT" :classifier "test"]]}
-             :testutils {:source-paths ^:replace ["test"]}}
+             :testutils {:source-paths ^:replace ["test"]}
+             :uberjar {:aot [puppetlabs.trapperkeeper.main]}}
 
   :main puppetlabs.trapperkeeper.main
   )


### PR DESCRIPTION
This may require an upgrade to lein 2.3.4 due to https://github.com/technomancy/leiningen/issues/1358
