### PR TITLE
Add explicit dependency on clojure.tools.logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [puppetlabs/kitchensink "0.3.1-SNAPSHOT"]
                  [org.eclipse.jetty/jetty-server "7.6.1.v20120215"]
                  [ring/ring-servlet "1.1.8"]
+                 [org.clojure/tools.logging "0.2.6"]
 
                  [prismatic/plumbing "0.1.0"]
                  [log4j "1.2.17" :exclusions [javax.mail/mail


### PR DESCRIPTION
We are using some of the log functions from clojure.tools.logging
in trapperkeeper.  However, prior to this commit, we weren't
explicitly specifying a dependency on it and were instead
inheriting it from kitchensink.

This makes the dependency explicit.
