### PR TITLE
(PE-2394) Fix lein uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,8 @@
 
              :testutils {:source-paths ^:replace ["test/clj"]
                          :java-source-paths ^:replace ["test/java"]}
-             :uberjar {:aot [puppetlabs.trapperkeeper.main]}}
+             :uberjar {:aot [puppetlabs.trapperkeeper.main]
+                       :classifiers ^:replace []}}
 
   :main puppetlabs.trapperkeeper.main
   )


### PR DESCRIPTION
This has the side effect that the test jar is no longer produced during uberjar, but that seems acceptable.
