### PR TITLE
(PE-2320) Clean up core namespace

### DIFF
--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -4,17 +4,21 @@
             [clojure.string :as string]
             [clojure.java.io :refer [reader resource file]]
             [clojure.tools.logging :as log]
-            [puppetlabs.trapperkeeper.app :refer [validate-service-graph! service-graph?]]))
+            [puppetlabs.trapperkeeper.config :refer [configure!]]
+            [puppetlabs.trapperkeeper.shutdown :refer [register-shutdown-hooks!]]
+            [puppetlabs.trapperkeeper.app :refer [validate-service-graph! service-graph?
+                                                  compile-graph instantiate]])
+  (:import (puppetlabs.trapperkeeper.app TrapperKeeperApp)))
 
 (def bootstrap-config-file-name "bootstrap.cfg")
 
-(defn parse-bootstrap-line!
+(defn- parse-bootstrap-line!
   "Parses an individual line from a trapperkeeper bootstrap configuration file.
   Each line is expected to be of the form: '<namespace>/<service-fn-name>'.  Returns
   a 2-item vector containing the namespace and the service function name.  Throws
   an IllegalArgumentException if the line is not valid."
   [line]
-  {:pre [(string? line)]
+  {:pre  [(string? line)]
    :post [(vector? %)
           (= 2 (count %))
           (every? string? %)]}
@@ -27,27 +31,24 @@
                   line
                   "\n\nAll lines must be of the form: '<namespace>/<service-fn-name>'.")))))
 
-(defn call-service-fn!
+(defn- call-service-fn!
   "Given the namespace and name of a service function, loads the namespace,
   calls the function, validates that the result is a valid service graph, and
   returns the graph.  Throws an `IllegalArgumentException` if the service graph
   cannot be loaded."
   [fn-ns fn-name]
-  {:pre [(string? fn-ns)
-         (string? fn-name)]
+  {:pre  [(string? fn-ns)
+          (string? fn-name)]
    :post [(service-graph? %)]}
   (try (require (symbol fn-ns))
        (catch FileNotFoundException e
          (throw (IllegalArgumentException.
-                  (str "Unable to load service: "
-                       fn-ns "/" fn-name)
+                  (str "Unable to load service: " fn-ns "/" fn-name)
                   e))))
-  (if-let [service-fn (ns-resolve (symbol fn-ns)
-                                  (symbol fn-name))]
+  (if-let [service-fn (ns-resolve (symbol fn-ns) (symbol fn-name))]
     (validate-service-graph! (service-fn))
     (throw (IllegalArgumentException.
-             (str "Unable to load service: "
-                  fn-ns "/" fn-name)))))
+             (str "Unable to load service: " fn-ns "/" fn-name)))))
 
 (defn- remove-comments
   "Given a line of text from the bootstrap config file, remove
@@ -60,28 +61,13 @@
       (string/replace #"(?:#|;).*$" "")
       (string/trim)))
 
-(defn parse-bootstrap-config!
-  "Parse the trapperkeeper bootstrap configuration and return the service graph
-  that is the result of merging the graphs of all of the services specified in
-  the configuration."
-  [config]
-  {:pre [(satisfies? IOFactory config)]
-   :post [(sequential? %)
-          (every? service-graph? %)]}
-  (let [lines (line-seq (reader config))]
-    (when (empty? lines) (throw (Exception. "Empty bootstrap config file")))
-    (for [line (map remove-comments lines)
-          :when (not (empty? line))]
-      (let [[service-fn-namespace service-fn-name] (parse-bootstrap-line! line)]
-        (call-service-fn! service-fn-namespace service-fn-name)))))
-
-(defn config-from-cli!
+(defn- config-from-cli
   "Given the data from the command-line (parsed via `core/parse-cli-args!`),
   check to see if the caller explicitly specified the location of the bootstrap
   config file.  If so, return it.  Throws an IllegalArgumentException if a
   location was specified but the file doesn't actually exist."
   [cli-data]
-  {:pre [(map? cli-data)]
+  {:pre  [(map? cli-data)]
    :post [(or (nil? %)
               (satisfies? IOFactory %))]}
   (when (contains? cli-data :bootstrap-config)
@@ -93,21 +79,21 @@
         (throw (IllegalArgumentException.
                  (str "Specified bootstrap config file does not exist: '" config-path "'")))))))
 
-(defn config-from-cwd
+(defn- config-from-cwd
   "Check to see if there is a bootstrap config file in the current working
   directory;  if so, return it."
   []
   {:post [(or (nil? %)
               (satisfies? IOFactory %))]}
   (let [config-file (-> bootstrap-config-file-name
-                        file
-                        .getAbsoluteFile)]
+                        (file)
+                        (.getAbsoluteFile))]
     (when (.exists config-file)
       (log/debug (str "Loading bootstrap config from current working directory: '"
                       (.getAbsolutePath config-file) "'"))
       config-file)))
 
-(defn config-from-classpath
+(defn- config-from-classpath
   "Check to see if there is a bootstrap config file available on the classpath;
   if so, return it."
   []
@@ -116,3 +102,64 @@
   (when-let [classpath-config (resource bootstrap-config-file-name)]
     (log/debug (str "Loading bootstrap config from classpath: '" classpath-config "'"))
     classpath-config))
+
+(defn- find-bootstrap-config
+  "Get the bootstrap config file from:
+    1. the file path specified on the command line, or
+    2. the current working directory, or
+    3. the classpath
+  Throws an exception if the file cannot be found."
+  [cli-data]
+  {:pre  [(map? cli-data)]
+   :post [(or (nil? %)
+              (satisfies? IOFactory %))]}
+  (if-let [bootstrap-config (or (config-from-cli cli-data)
+                                (config-from-cwd)
+                                (config-from-classpath))]
+    bootstrap-config
+    (throw (IllegalStateException.
+             (str "Unable to find bootstrap.cfg file via --bootstrap-config "
+                  "command line argument, current working directory, or on classpath")))))
+
+(defn parse-bootstrap-config!
+  "Parse the trapperkeeper bootstrap configuration and return the service graph
+  that is the result of merging the graphs of all of the services specified in
+  the configuration."
+  [config]
+  {:pre  [(satisfies? IOFactory config)]
+   :post [(sequential? %)
+          (every? service-graph? %)]}
+  (let [lines (line-seq (reader config))]
+    (when (empty? lines) (throw (Exception. "Empty bootstrap config file")))
+    (for [line (map remove-comments lines)
+          :when (not (empty? line))]
+      (let [[service-fn-namespace service-fn-name] (parse-bootstrap-line! line)]
+        (call-service-fn! service-fn-namespace service-fn-name)))))
+
+(defn bootstrap-services
+  "Given the services to run and command-line arguments,
+  bootstrap and return the trapperkeeper application."
+  [services cli-data]
+  {:pre  [(sequential? services)
+          (every? service-graph? services)
+          (map? cli-data)]
+   :post [(instance? TrapperKeeperApp %)]}
+  (-> cli-data
+      (configure! services)
+      (register-shutdown-hooks!)
+      (compile-graph)
+      (instantiate)
+      (TrapperKeeperApp.)))
+
+(defn bootstrap
+  "Get the services out of the bootstrap config file
+  provided in `cli-data` and bootstrap the application.
+  See `puppetlabs.trapperkeeper.core/bootstrap` for information."
+  [cli-data]
+  {:pre  [(map? cli-data)
+          (contains? cli-data :config)]
+   :post [(instance? TrapperKeeperApp %)]}
+  (-> cli-data
+      (find-bootstrap-config)
+      (parse-bootstrap-config!)
+      (bootstrap-services cli-data)))

--- a/src/puppetlabs/trapperkeeper/config.clj
+++ b/src/puppetlabs/trapperkeeper/config.clj
@@ -1,0 +1,49 @@
+(ns puppetlabs.trapperkeeper.config
+  (:import  (java.io FileNotFoundException))
+  (:require [clojure.java.io :refer [file]]
+            [puppetlabs.kitchensink.core :refer [inis-to-map]]
+            [puppetlabs.trapperkeeper.services :refer [service]]
+            [puppetlabs.trapperkeeper.logging :refer [configure-logging!]]))
+
+(defn- config-service
+  "A simple configuration service based on .ini config files.  Expects
+   to find a command-line argument value for `:config`; the value of this
+   parameter should be the path to an .ini file or a directory of .ini
+   files.
+
+   Provides a function, `get-in-config`, which can be used to
+   retrieve the config data read from the ini files.  For example,
+   given an ini file with the following contents:
+
+       [foo]
+       bar = baz
+
+   The value of `(get-in-config [:foo :bar])` would be `\"baz\"`.
+
+   Also provides a second function, `get-config`, which simply returns
+   the entire configuration map."
+  [config]
+  ((service :config-service
+    {:depends  []
+     :provides [get-in-config get-config]}
+    {:get-in-config (partial get-in config)
+     :get-config    (fn [] config)})))
+
+(defn- parse-config-file
+  [config-file-path]
+  {:pre  [(not (nil? config-file-path))]
+   :post [(map? %)]}
+  (when-not (.canRead (file config-file-path))
+    (throw (FileNotFoundException.
+             (format "Configuration path '%s' must exist and must be readable." config-file-path))))
+  (inis-to-map config-file-path))
+
+(defn configure!
+  [cli-data services]
+  (let [debug?      (or (:debug cli-data) false)
+        config-data (-> (:config cli-data)
+                        (parse-config-file)
+                        (assoc :debug debug?))
+        log-config  (get-in config-data [:global :logging-config])]
+    (configure-logging! log-config debug?)
+    (apply merge (config-service config-data) services)))

--- a/test/clj/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/core_test.clj
@@ -86,11 +86,11 @@
 
 (deftest test-debug
   (testing "debug mode is off by default"
-    (let [app (bootstrap-services-with-empty-config [])
+    (let [app           (bootstrap-services-with-empty-config [])
           get-in-config (get-service-fn app :config-service :get-in-config)]
       (is (false? (get-in-config [:debug]))))))
 
   (testing "--debug puts TK in debug mode"
-    (let [app (bootstrap*-with-empty-config [] ["--debug"])
+    (let [app           (bootstrap-services-with-empty-config [] ["--debug"])
           get-in-config (get-service-fn app :config-service :get-in-config)]
       (is (true? (get-in-config [:debug])))))

--- a/test/clj/puppetlabs/trapperkeeper/services/config/config_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/config/config_service_test.clj
@@ -1,12 +1,12 @@
 (ns puppetlabs.trapperkeeper.services.config.config-service-test
   (:import (java.io StringReader FileNotFoundException))
   (:require [clojure.test :refer :all]
-            [puppetlabs.trapperkeeper.core :refer [bootstrap*]]
+            [puppetlabs.trapperkeeper.bootstrap :refer [bootstrap-services]]
             [puppetlabs.trapperkeeper.services :refer [defservice get-service-fn]]))
 
 (defservice test-service
    {:depends [[:config-service get-in-config get-config]]
-    :provides []}
+    :provides [test-fn test-fn-2 get-in-config]}
    {:test-fn (fn [ks] (get-in-config ks))
     :test-fn-2 (fn [] (get-config))
     :get-in-config get-in-config})
@@ -16,10 +16,10 @@
     (is (thrown-with-msg?
           FileNotFoundException
           #"Configuration path './foo/bar/baz' must exist and must be readable."
-          (bootstrap* [(test-service)] {:config "./foo/bar/baz"}))))
+          (bootstrap-services [(test-service)] {:config "./foo/bar/baz"}))))
 
   (testing "Can read values from a single .ini file"
-    (let [app       (bootstrap* [(test-service)] {:config "./test-resources/config/file/config.ini"})
+    (let [app       (bootstrap-services [(test-service)] {:config "./test-resources/config/file/config.ini"})
           test-fn   (get-service-fn app :test-service :test-fn)
           test-fn-2 (get-service-fn app :test-service :test-fn-2)]
       (is (= (test-fn [:foo :setting1]) "foo1"))
@@ -30,13 +30,13 @@
         (is (= (test-fn-2) {:foo {:setting2 "foo2", :setting1 "foo1"}, :bar {:setting1 "bar1"} :debug false} )))))
 
   (testing "Can read values from a directory of .ini files"
-    (let [app     (bootstrap* [(test-service)] {:config "./test-resources/config/dir"})
+    (let [app     (bootstrap-services [(test-service)] {:config "./test-resources/config/dir"})
           test-fn (get-service-fn app :test-service :test-fn)]
       (is (= (test-fn [:baz :setting1]) "baz1"))
       (is (= (test-fn [:baz :setting2]) "baz2"))
       (is (= (test-fn [:bam :setting1]) "bam1"))))
 
   (testing "A proper default value is returned if a key can't be found"
-    (let [app     (bootstrap* [(test-service)] {:config "./test-resources/config/dir"})
+    (let [app     (bootstrap-services [(test-service)] {:config "./test-resources/config/dir"})
           test-fn (get-service-fn app :test-service :get-in-config)]
       (is (= (test-fn [:doesnt :exist] "foo") "foo")))))

--- a/test/clj/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/jetty/jetty_service_test.clj
@@ -2,7 +2,7 @@
   (:import  [servlet SimpleServlet])
   (:require [clojure.test :refer :all]
             [clj-http.client :as http-client]
-            [puppetlabs.trapperkeeper.core :refer [bootstrap*]]
+            [puppetlabs.trapperkeeper.bootstrap :refer [bootstrap-services]]
             [puppetlabs.trapperkeeper.services :refer [get-service-fn]]
             [puppetlabs.trapperkeeper.services.jetty.jetty-service :refer :all]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [bootstrap-services-with-empty-config]]
@@ -12,7 +12,7 @@
 
 (deftest jetty-webserver-service
   (testing "ring support"
-    (let [app              (bootstrap* [(webserver-service)] {:config "./test-resources/config/jetty/jetty.ini"})
+    (let [app              (bootstrap-services [(webserver-service)] {:config "./test-resources/config/jetty/jetty.ini"})
           add-ring-handler (get-service-fn app :webserver-service :add-ring-handler)
           join             (get-service-fn app :webserver-service :join)
           shutdown         (get-service-fn app :webserver-service :shutdown)
@@ -50,7 +50,7 @@
   (testing "SSL initialization is supported for both .jks and .pem implementations"
     (doseq [config ["./test-resources/config/jetty/jetty-ssl-jks.ini"
                     "./test-resources/config/jetty/jetty-ssl-pem.ini"]]
-      (let [app               (bootstrap* [(webserver-service)] {:config config})
+      (let [app               (bootstrap-services [(webserver-service)] {:config config})
             add-ring-handler  (get-service-fn app :webserver-service :add-ring-handler)
             join              (get-service-fn app :webserver-service :join)
             shutdown          (get-service-fn app :webserver-service :shutdown)

--- a/test/clj/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
@@ -1,27 +1,18 @@
 (ns puppetlabs.trapperkeeper.services.nrepl.nrepl-service-test
   (:require [clojure.test :refer :all]
             [clojure.tools.nrepl :as repl]
-            [puppetlabs.trapperkeeper.core :refer [bootstrap*]]
+            [puppetlabs.trapperkeeper.bootstrap :refer [bootstrap-services]]
             [puppetlabs.trapperkeeper.services :refer [get-service-fn]]
             [puppetlabs.trapperkeeper.services.nrepl.nrepl-service :refer :all]))
 
 (deftest test-nrepl-service
   (testing "An nREPL service has been started"
-    (let [services  [(nrepl-service)]
-          cli-data  {:config "./test-resources/config/nrepl/nrepl.ini"}
-          tk-app    (bootstrap* services cli-data)
-          shutdown  (get-service-fn tk-app :nrepl-service :shutdown)]
+    (let [app      (bootstrap-services [(nrepl-service)] {:config "./test-resources/config/nrepl/nrepl.ini"})
+          shutdown (get-service-fn app :nrepl-service :shutdown)]
       (try
         (is (= [2] (with-open [conn (repl/connect :port 7888)]
-                  (-> (repl/client conn 1000)
-                      (repl/message {:op "eval" :code "(+ 1 1)"})
-                      repl/response-values))))
+                     (-> (repl/client conn 1000)
+                         (repl/message {:op "eval" :code "(+ 1 1)"})
+                         (repl/response-values)))))
       (finally
         (shutdown))))))
-
-
-
-
-
-
-

--- a/test/clj/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.trapperkeeper.services :refer :all]
             [puppetlabs.trapperkeeper.app :refer [service-graph?]]
             [puppetlabs.trapperkeeper.examples.bootstrapping.test-services :refer [hello-world-service]]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [bootstrap-services-with-empty-config bootstrap-framework-with-no-services]]))
+            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [bootstrap-services-with-empty-config]]))
 
 (deftest defservice-macro
   (def logging-service
@@ -66,17 +66,15 @@
                       {:depends []}
                       {})"))))))
 
-(deftest missing-service
-  (testing "`get-service-fn` throws a useful error message if the service or service fn does not exist"
+(deftest get-service-fn-test
+  (testing "throws a useful error message if the service or service fn does not exist"
     (is (thrown-with-msg?
           IllegalArgumentException
           #"(?s)^.*Service .* not found in graph.*$"
-          (->
-            (bootstrap-framework-with-no-services)
-            (get-service-fn :service :service-fn))))
+          (-> (bootstrap-services-with-empty-config [])
+              (get-service-fn :service :service-fn))))
     (is (thrown-with-msg?
           IllegalArgumentException
           #"(?s)^.*service function.* not found in graph.*$"
-          (->
-            (bootstrap-services-with-empty-config [(hello-world-service)])
-            (get-service-fn :simple-service :invalid-service-fn))))))
+          (-> (bootstrap-services-with-empty-config [(hello-world-service)])
+              (get-service-fn :simple-service :invalid-service-fn))))))

--- a/test/clj/puppetlabs/trapperkeeper/testutils/bootstrap.clj
+++ b/test/clj/puppetlabs/trapperkeeper/testutils/bootstrap.clj
@@ -5,8 +5,12 @@
 (def empty-config "./test-resources/config/empty.ini")
 
 (defn bootstrap-services-with-empty-config
-  [services]
-  (trapperkeeper/bootstrap* services {:config empty-config}))
+  ([services]
+    (bootstrap/bootstrap-services services {:config empty-config}))
+  ([services other-args]
+    (->> (conj other-args "--config" empty-config)
+         (trapperkeeper/parse-cli-args!)
+         (bootstrap/bootstrap-services services))))
 
 (defn bootstrap-with-empty-config
   ([]
@@ -15,23 +19,12 @@
    (-> other-args
        (conj "--config" empty-config )
        (trapperkeeper/parse-cli-args!)
-       (trapperkeeper/bootstrap))))
-
-(defn bootstrap*-with-empty-config
-  [services other-args]
-  (let [cli-data (->
-                   (conj other-args "--config" empty-config)
-                   (trapperkeeper/parse-cli-args!))]
-    (trapperkeeper/bootstrap* services cli-data)))
+       (bootstrap/bootstrap))))
 
 (defn parse-and-bootstrap
   ([bootstrap-config]
    (parse-and-bootstrap bootstrap-config {:config empty-config}))
   ([bootstrap-config cli-data]
    (-> bootstrap-config
-       bootstrap/parse-bootstrap-config!
-       (trapperkeeper/bootstrap* cli-data))))
-
-(defn bootstrap-framework-with-no-services
-  []
-  (trapperkeeper/bootstrap* [] {:config empty-config}))
+       (bootstrap/parse-bootstrap-config!)
+       (bootstrap/bootstrap-services cli-data))))


### PR DESCRIPTION
Refactorings include:
- Extracted config code into own namespace
- Pushed bootstrapping functions down into bootstrap namespace
  - Left forwarding function in core for accessible API
  - Renamed bootstrap\* to bootstrap-services
- Moved compile/instantiate functions into app namespace
- Converted let blocks into -> pipelines
- Consolidated and cleaned up bootstrap testutils
