### PR TITLE
Fix default test path and fix broken test in core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,8 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
+  :test-paths ["test/clj"]
+
   :profiles {:dev {:test-paths ["test-resources"]
                    :source-paths ["examples/shutdown_app/src"
                                   "examples/ring_app/src"
@@ -42,7 +44,6 @@
              :test {:dependencies [[clj-http "0.5.3"]
                                    [org.slf4j/slf4j-log4j12 "1.7.5"]
                                    [puppetlabs/kitchensink "0.4.0" :classifier "test"]]
-                    :test-paths ["test/clj"]
                     :java-source-paths ["test/java"]}
 
              :testutils {:source-paths ^:replace ["test/clj"]

--- a/test/clj/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/core_test.clj
@@ -88,9 +88,9 @@
   (testing "debug mode is off by default"
     (let [app           (bootstrap-services-with-empty-config [])
           get-in-config (get-service-fn app :config-service :get-in-config)]
-      (is (false? (get-in-config [:debug]))))))
+      (is (false? (get-in-config [:debug])))))
 
   (testing "--debug puts TK in debug mode"
     (let [app           (bootstrap-services-with-empty-config [] ["--debug"])
           get-in-config (get-service-fn app :config-service :get-in-config)]
-      (is (true? (get-in-config [:debug])))))
+      (is (true? (get-in-config [:debug]))))))


### PR DESCRIPTION
This commit does the following:
- Move the `:test-paths ["test/clj"]` in the project file up to the
  root level of the project file.  It had previously been located
  inside of a profile.  My understanding is that when you define
  these path settings inside of a profile, they do not override
  the project-wide values, but rather supplement them.  In this
  case, the default is `test`, but our tests actually live in
  `test/clj`.  This was causing IDEA to incorrectly set up the
  source paths (and, technically, I believe it would make the
  namespaces in our clojure test code invalid).
- Fix some errant parens in `core_test`; the final test in the
  file was outside of a `deftest` block, and thus was not
  actually being run.
