### PR TITLE
(PE-2415) fix error handling on bad CLI args

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ks-version "0.4.2")
+(def ks-version "0.5.0")
 
 (defproject puppetlabs/trapperkeeper "0.3.0-SNAPSHOT"
   :description "We are trapperkeeper.  We are one."

--- a/src/puppetlabs/trapperkeeper/config.clj
+++ b/src/puppetlabs/trapperkeeper/config.clj
@@ -35,7 +35,7 @@
 
 (defn- parse-config-file
   [config-file-path]
-  {:pre  [(not (nil? config-file-path))]
+  {:pre  [(string? config-file-path)]
    :post [(map? %)]}
   (when-not (.canRead (file config-file-path))
     (throw (FileNotFoundException.

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -98,10 +98,10 @@
   [cli-args]
   {:pre  [(sequential? cli-args)]
    :post [(map? %)]}
-  (let [specs       [["-d" "--debug" "Turns on debug mode" :flag true]
-                     ["-b" "--bootstrap-config" "Path to bootstrap config file"]
-                     ["-c" "--config" "Path to .ini file or directory of .ini files to be read and consumed by services"]
-                     ["-p" "--plugins" "Path to directory plugin .jars"]]
+  (let [specs       [["-d" "--debug" "Turns on debug mode"]
+                     ["-b" "--bootstrap-config BOOTSTRAP-CONFIG-FILE" "Path to bootstrap config file"]
+                     ["-c" "--config CONFIG-PATH" "Path to .ini file or directory of .ini files to be read and consumed by services"]
+                     ["-p" "--plugins PLUGINS-DIRECTORY" "Path to directory plugin .jars"]]
         required    [:config]]
     (first (cli! cli-args specs required))))
 


### PR DESCRIPTION
Previously, calling 'main' with an invalid CLI arg would cause a nasty
exception to be thrown and logged.  This fixes that to print the
banner message about CLI arguments and kill the process.

This results in the following behavior if you run TK with an invalid CLI arg:

```
(main "--foo")


Error(s) occurred while parsing command-line arguments: Unknown option: "--foo"

  -d, --debug                                   Turns on debug mode
  -b, --bootstrap-config BOOTSTRAP-CONFIG-FILE  Path to bootstrap config file
  -c, --config CONFIG-PATH                      Path to .ini file or directory of .ini files to be read and consumed by services
  -p, --plugins PLUGINS-DIRECTORY               Path to directory plugin .jars
  -h, --help                                    Show help

Process finished with exit code 1
```
