### PR TITLE
Coorce a lack of arguments into the empty list

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -157,7 +157,7 @@
   {:pre [((some-fn sequential? nil?) args)
          (every? string? args)]}
   (try+
-    (-> args
+    (-> (or args '())
         (internal/parse-cli-args!)
         (run))
     (catch map? m


### PR DESCRIPTION
The variable in the rest position of the positional args will be
nil if there are no further arguments.  This commit uses or to
ensure we get an empty list.

```
user=> (defn foo [& args] args)
#'user/foo
user=> (foo 1 2 3)
(1 2 3)
user=> (foo)
nil
```
