### PR TITLE
bump version to 0.4.0-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ks-version "0.5.1")
 
-(defproject puppetlabs/trapperkeeper "0.3.4-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper "0.4.0-SNAPSHOT"
   :description "We are trapperkeeper.  We are one."
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.


### PR DESCRIPTION
master should not be on 0.3.anything since we have an 0.3.x branch
