### PR TITLE
(PE-2741) improve `service` macro error handling

### DIFF
--- a/src/puppetlabs/trapperkeeper/services_internal.clj
+++ b/src/puppetlabs/trapperkeeper/services_internal.clj
@@ -204,6 +204,17 @@
 
   (let [fns-map (->> (reduce
                        (fn [acc f]
+                         ; second element should be a vector - params to the fn
+                         (when-not (vector? (second f))
+                           ; macro was used incorrectly - perhaps the user
+                           ; mistakenly tried to insert a docstring, like:
+                           ; `(service-fn "docs about service-fn..." [this] ... )`
+                           (throw
+                             (Exception.
+                               (str
+                                 "Incorrect macro usage: service functions must "
+                                 "be defined the same as a call to `reify`, eg: "
+                                 "`(my-service-fn [this other-args] ...)`"))))
                          (let [k    (keyword (first f))
                                cur  (acc k)]
                            (if cur

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -270,3 +270,14 @@
       (is (= 3 (foo mas 3)))
       (is (= 5 (foo mas 4 1)))
       (is (= [5 9] (service1-fn s1))))))
+
+(deftest service-fn-invalid-docstring
+  (testing "defining a service function, mistakenly adding a docstring"
+    (is (thrown-with-msg?
+          Exception
+          #"Incorrect macro usage"
+          (macroexpand '(service Service1
+                                 []
+                                 (service1-fn
+                                   "This is an example of an invalid docstring"
+                                   [this] nil)))))))


### PR DESCRIPTION
Throw a more informative error message when the user incorrectly tries
to include a docstring on a service function implementation.
