### PR TITLE
Log exceptions that occur during bootstrapping

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -405,9 +405,13 @@
           (every? #(satisfies? s/ServiceDefinition %) services)
           (map? config-data)]
    :post [(satisfies? a/TrapperkeeperApp %)]}
-  (let [app (build-app* services config-data)]
-    (a/init app)
-    (a/start app)
-    app))
+  (try
+    (let [app (build-app* services config-data)]
+      (a/init app)
+      (a/start app)
+      app)
+    (catch Throwable t
+      (log/error t)
+      (throw t))))
 
 


### PR DESCRIPTION
Prior to this commit, if an exception was thrown during
bootstrapping (e.g., during an `init` or `start` lifecycle phase),
we would correctly bubble that exception up to the main thread,
but we would not write it to the logger.  This makes it
difficult to see what's going wrong in a production environment.

This commit adds a try/catch to log these exceptions and
re-throw them.
