### PR TITLE
(PE-3047) Call shutdown-agents at end of shutdown processing

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -164,4 +164,6 @@
       (println (:message m))
       (case (without-ns (:type m))
         :cli-error (System/exit 1)
-        :cli-help  (System/exit 0)))))
+        :cli-help  (System/exit 0)))
+    (finally
+      (shutdown-agents))))


### PR DESCRIPTION
This commit adds a call to clojure.core/shutdown-agents to the end of
Trapperkeeper core's main function.  This allows agent thread pools to
start shutdown processing sooner than the default delay which would
occur in the shutdown of these pools.  This is especially useful for
allowing the JVM process running Trapperkeeper to terminate quickly when
an error has occurred during startup.
