### PR TITLE
Make test Logger return nil from logging functions.

### DIFF
--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -53,7 +53,8 @@
          (write! [_ lvl ex msg]
            (let [entry [(str log-ns) lvl ex msg]]
              (when debug (log-to-console entry))
-             (swap! output-atom conj entry))))))))
+             (swap! output-atom conj entry)
+             nil)))))))
 
 (defn atom-appender
   "Creates a logback appender that writes log messages to the supplied atom"


### PR DESCRIPTION
Make the Logger used by with-test-logging and friends return nil from
functions like log/info.  This conforms to the normal logging API.
Previously, it was returning the value of its atom.
