### PR TITLE
(PE-3369) Remove clj-http dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,6 @@
                                   "examples/java_service/src/clj"]
                    :java-source-paths ["examples/java_service/src/java"]
                    :dependencies [[spyscope "0.1.4"]
-                                  [clj-http "0.5.3"]
                                   [puppetlabs/kitchensink ~ks-version :classifier "test"]]
                    :injections [(require 'spyscope.core)]}
 


### PR DESCRIPTION
Remove clj-http dependency from tests. Did not replace
with clj-http-client, as the clj-http dependency was not
being used anywhere in the tests.
