### PR TITLE
(TK-13) Change example to use .conf

### DIFF
--- a/examples/java_service/README.md
+++ b/examples/java_service/README.md
@@ -2,5 +2,5 @@ Example: Building a Trapperkeeper service that wraps java code
 --------------------------------------------------------------
 To run the example:
 
-    lein trampoline run --config ./examples/java_service/config.ini \
+    lein trampoline run --config ./examples/java_service/config.conf \
                     --bootstrap-config ./examples/java_service/bootstrap.cfg

--- a/examples/java_service/config.conf
+++ b/examples/java_service/config.conf
@@ -1,0 +1,4 @@
+global {
+    # Points to a logback config file
+    logging-config = examples/java_service/logback.xml
+}

--- a/examples/java_service/config.ini
+++ b/examples/java_service/config.ini
@@ -1,3 +1,0 @@
-[global]
-# Points to a logback config file
-logging-config = examples/java_service/logback.xml


### PR DESCRIPTION
Change the Java server example to use a .conf file instead of a
.ini file for its configuration information.
