### PR TITLE
(TK-56) Call service-symbol in lifecycle errors

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -147,7 +147,7 @@
                (format
                  "Lifecycle function '%s' for service '%s' must return a context map (got: %s)"
                  lifecycle-fn-name
-                 (str (s/service-symbol s))
+                 (or (s/service-symbol s) service-id)
                  (pr-str updated-ctxt)))))
     ;; store the updated service context map in the application context atom
     (swap! app-context assoc service-id updated-ctxt)))

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -201,6 +201,30 @@
           (bootstrap-services-with-empty-config [service1-alt]))
         "Unexpected shutdown reason for bootstrap"))
 
+  (testing "lifecycle error works if service has no service symbol"
+    (let [service1 (service Service1
+                            []
+                            (init [this context] "hi")
+                            (service1-fn [this] "hi"))]
+      (is (thrown-with-msg?
+            IllegalStateException
+            (re-pattern (str "Lifecycle function 'init' for service ':Service1'"
+                             " must return a context map \\(got: \"hi\"\\)"))
+            (bootstrap-services-with-empty-config [service1]))
+          "Unexpected shutdown reason for bootstrap"))
+    (let [service1 (service Service1
+                            []
+                            (start [this context] "hi")
+                            (service1-fn [this] "hi"))]
+
+      (is (thrown-with-msg?
+            IllegalStateException
+            (re-pattern (str "Lifecycle function 'start' for service "
+                             "':Service1' must return a context map "
+                             "\\(got: \"hi\"\\)"))
+            (bootstrap-services-with-empty-config [service1]))
+          "Unexpected shutdown reason for bootstrap")))
+
   (testing "context should be available in subsequent lifecycle functions"
     (let [start-context (atom nil)
           service1 (service Service1


### PR DESCRIPTION
Call the service-symbol function in lifecycle error messages
to make it easier to figure out which service is causing
the error.
