### PR TITLE
(TK-113) allow multiple comma-separated config files/dirs

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -117,7 +117,8 @@
   (let [specs       [["-d" "--debug" "Turns on debug mode"]
                      ["-b" "--bootstrap-config BOOTSTRAP-CONFIG-FILE" "Path to bootstrap config file"]
                      ["-c" "--config CONFIG-PATH"
-                      (str "Path to a configuration file or directory of configuration files. "
+                      (str "Path to a configuration file or directory of configuration files, "
+                           "or a comma-separated list of such paths."
                            "See the documentation for a list of supported file types.")]
                      ["-p" "--plugins PLUGINS-DIRECTORY" "Path to directory plugin .jars"]]
         required    []]


### PR DESCRIPTION
This patch allows the specification of multiple config files and directories
in the config CLI argument like so:

lein run services --config dir1,dir2

Errors should be thrown in all cases one would expect if the contents of the configs were instead under a single directory.
