### PR TITLE
(TK-118) Fix lack of console logging with --debug

### DIFF
--- a/src/puppetlabs/trapperkeeper/logging.clj
+++ b/src/puppetlabs/trapperkeeper/logging.clj
@@ -45,7 +45,10 @@
   ([level]
    {:pre [(instance? Level level)]}
    (let [layout (PatternLayout.)]
-     (.setPattern layout "%d %-5p [%t] [%c{2}] %m%n")
+     (doto layout
+       (.setContext (logging-context))
+       (.setPattern "%d %-5p [%t] [%c{2}] %m%n")
+       (.start))
      (doto (ConsoleAppender.)
        (.setContext (logging-context))
        (.setLayout layout)


### PR DESCRIPTION
Fix an issue wherein nothing was logged to the console when the
--debug flag was set.
