### PR TITLE
(TK-142) Add support for logback evaluator filters

### DIFF
--- a/dev-resources/logging/logback-evaluator-filter.xml
+++ b/dev-resources/logging/logback-evaluator-filter.xml
@@ -1,0 +1,37 @@
+<!-- This is only used as a test file, not for actually configuring logging during tests -->
+<configuration>
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <matcher>
+                    <Name>matcher</Name>
+                    <regex>should get filtered</regex>
+                </matcher>
+                <expression>matcher.matches(formattedMessage)</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <matcher>
+                    <Name>omgMatcher</Name>
+                    <regex>OMGOMG</regex>
+                </matcher>
+                <expression>omgMatcher.matches(throwable.getMessage())</expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
+
+        <file>./target/test/logback-evaluator-filter-test.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="F1" />
+    </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,14 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.logging "0.2.6"]
+                 [clj-time "0.5.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [prismatic/plumbing "0.2.1"]
                  [prismatic/schema "0.2.2"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [org.clojure/tools.macro "0.1.2"]
                  [ch.qos.logback/logback-classic "1.1.1"]
+                 [org.codehaus.janino/janino "2.7.8"]
                  [puppetlabs/typesafe-config "0.1.1"]
                  [me.raynes/fs "1.4.5"]]
 


### PR DESCRIPTION
This commit adds support for logback's EvaluatorFilters.  These
require a dependency that we didn't have before (janino), and
allow really powerful scripting constructs to be specified
in the logback config file.  This will be extremely useful for
support escalations, e.g. in cases where we need to prevent
a problematic log message from bloating the log files on disk.