### PR TITLE
(maint) remove mention of IRC channel from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Add the following dependency to your `project.clj` file:
 ## Community
 
 * Bug reports and feature requests: you can submit a Github issue, but we use [JIRA](https://tickets.puppetlabs.com/browse/TK) as our main issue tracker.
-* freenode: #trapperkeeper
 
 
 ## Documentation


### PR DESCRIPTION
We probably don't need both IRC and Gitter.