### PR TITLE
(TK-131) Remove precondition from `configure-logger!`

### DIFF
--- a/src/puppetlabs/trapperkeeper/logging.clj
+++ b/src/puppetlabs/trapperkeeper/logging.clj
@@ -73,9 +73,13 @@
        (.setLevel root level)))))
 
 (defn configure-logger!
-  "Reconfigures the current logger based on the supplied configuration."
+  "Reconfigures the current logger based on the supplied configuration.
+
+  Supplied configuration can be a file path, url, file, InputStream, or
+  InputSource. It is passed along unchanged to `doConfigure` for
+  JoranConfigurator. For more information, see the documentation for
+  ch.qos.logback.core.classic.joran.JoranConfigurator."
   [logging-conf]
-  {:pre [(#{String java.io.File java.net.URL java.io.InputStream org.xml.sax.InputSource} (type logging-conf))]}
   (let [configurator (JoranConfigurator.)
         context      (LoggerFactory/getILoggerFactory)]
     (.setContext configurator (LoggerFactory/getILoggerFactory))
@@ -83,9 +87,11 @@
     (.doConfigure configurator logging-conf)))
 
 (defn configure-logging!
-  "Takes a file path, url, file, or InputStream which can define how to
-  configure the logging system.
-  
+  "Takes a file path, url, file, InputStream, or InputSource which can
+  define how to configure the logging system. This is passed unchanged
+  to the `doConfigure` method for the underlying JoranConfigurator
+  class.
+
   Also takes an optional `debug` flag which turns on debug logging."
   ([logging-conf]
    (configure-logging! logging-conf false))


### PR DESCRIPTION
Previously, the `configure-logger!` function had a precondition asserting that
the `logging-conf` argument passed to it matched one of five different types.
The argument is passed through to the `doConfigure` method for the
JoranConfigurator class.

The benefit to having the precondition is a more explicit error message in the
case where `logging-conf` is of a type that `doConfigure` doesn't accept.
However, the downside to this is that we have to have a long list of all the
possibilities, which we previously got wrong, thereby artificially
constraining what could be used to configure logging. Thus, this commit
removes the precondition completely and updates the relevant docstring.

With this change, the error message if an argument of incorrect
type is used is not very informative:

    java.lang.IllegalArgumentException: No matching method found: doConfigure for
    class ch.qos.logback.classic.joran.JoranConfigurator

However, in order for someone to encounter this, they would have to be
configuring logging from code, not from a config file, and could reasonably be
expected to already be looking at the documentation for JoranConfigurator, or
to be able to familiarize themselves with this easily.