### PR TITLE
(maint) Preserve stack, etc. when rethrowing in main

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -166,6 +166,6 @@
        (case (without-ns (:type m))
          :cli-error (quit 1 (:message m) *err*)
          :cli-help (quit 0 (:message m) *out*)
-         (throw+ m)))
+         (throw+)))
      (finally
        (shutdown-agents)))))


### PR DESCRIPTION
Explicitly rethrowing the pending exception adds another wrapper,
whereas (throw+) just passes on the existing exception.

The relevant bit from the throw+ docstring:

  Within a try+ catch clause, a throw+ call with no arguments rethrows
  the caught object within its original (possibly nested) wrappers.