### PR TITLE
Refactor testutils.logging/logs-matching to match on message and level.

### DIFF
--- a/test/puppetlabs/trapperkeeper/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/logging_test.clj
@@ -46,3 +46,16 @@
       (let [lines (line-seq reader)]
         (is (= 1 (count lines)))
         (is (re-matches #".*Hi! I shouldn't get filtered\..*" (first lines)))))))
+
+(deftest test-logs-matching
+  (let [log-lines '([puppetlabs.trapperkeeper.logging-test :info nil "log message1 at info"]
+                    [puppetlabs.trapperkeeper.logging-test :debug nil "log message1 at debug"]
+                    [puppetlabs.trapperkeeper.logging-test :warn nil "log message2 at warn"])]
+
+    (testing "logs-matching can filter on message"
+      (is (= 2 (count (logs-matching #"log message1" log-lines)))))
+
+    (testing "logs-matching can filter on message and level"
+      (is (= 1 (count (logs-matching #"log message1" log-lines :debug))))
+      (is (= "log message1 at debug" (-> (logs-matching #"log message1" log-lines :debug) first :message)))
+      (is (empty? (logs-matching #"log message2" log-lines :info))))))


### PR DESCRIPTION
Previously, logs-matching only filtered based on the log message and
given regex. The logged? assertion then checked to ensure there was
exactly 1 matching log line before considering the specified
log level. This led to the assertion failing in situations where
more than one log message matched even if one of the matches was at a
different level than the one specified in the assertion.