### PR TITLE
(TK-291) Handle all events in testutils.logging

### DIFF
--- a/src/puppetlabs/trapperkeeper/logging.clj
+++ b/src/puppetlabs/trapperkeeper/logging.clj
@@ -14,9 +14,11 @@
   []
   (.reset (logging-context)))
 
+(def root-logger-name Logger/ROOT_LOGGER_NAME)
+
 (defn root-logger
   []
-  (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME))
+  (LoggerFactory/getLogger root-logger-name))
 
 (defn catch-all-logger
   "A logging function useful for catch-all purposes, that is, to

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -8,12 +8,16 @@
             [puppetlabs.trapperkeeper.services :refer [service-map]]
             [puppetlabs.trapperkeeper.app :refer [get-service]]
             [puppetlabs.trapperkeeper.bootstrap :refer :all]
+            [puppetlabs.trapperkeeper.logging :refer [reset-logging]]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [bootstrap-with-empty-config parse-and-bootstrap]]
             [puppetlabs.trapperkeeper.examples.bootstrapping.test-services :refer [test-fn hello-world]]
             [schema.test :as schema-test]))
 
-(use-fixtures :once schema-test/validate-schemas)
+(use-fixtures :once
+  schema-test/validate-schemas
+  ;; Without this, "lein test NAMESPACE" and :only invocations may fail.
+  (fn [f] (reset-logging) (f)))
 
 (deftest bootstrapping
   (testing "Valid bootstrap configurations"

--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -272,9 +272,10 @@
   [& body]
   `(let [destination# (atom [])]
      (binding [*test-log-events* destination#]
-       (with-log-level root-logger-name :trace
-         (with-logging-to-atom root-logger-name destination#
-           ~@body)))))
+       (with-redefs [pl-log/configure-logger! (fn [& _#])]
+         (with-log-level root-logger-name :trace
+                         (with-logging-to-atom root-logger-name destination#
+                                               ~@body))))))
 
 (defmacro with-test-logging-debug
   "Creates an environment for the use of the logged? test method, and

--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -1,28 +1,361 @@
 (ns puppetlabs.trapperkeeper.testutils.logging
-  (:import (java.util.regex Pattern)
-           (org.slf4j LoggerFactory Logger)
-           (ch.qos.logback.core AppenderBase))
-  (:require [clojure.tools.logging.impl :as impl]
-            [clojure.tools.logging :refer [*logger-factory*]]
-            [clojure.test :refer [assert-expr]]
-            [puppetlabs.trapperkeeper.logging :as pl-log]))
+  (:import
+   [ch.qos.logback.classic Level Logger]
+   [ch.qos.logback.classic.encoder PatternLayoutEncoder]
+   [ch.qos.logback.core Appender FileAppender]
+   [ch.qos.logback.core.spi LifeCycle]
+   (ch.qos.logback.core AppenderBase)
+   [org.slf4j LoggerFactory]
+   [java.util.regex Pattern])
+  (:require
+   [clojure.set :as set]
+   [clojure.test]
+   [clojure.tools.logging.impl :as impl]
+   [clojure.tools.logging :refer [*logger-factory*]]
+   [me.raynes.fs :as fs]
+   [puppetlabs.kitchensink.core :as kitchensink]
+   [puppetlabs.trapperkeeper.logging :as pl-log
+    :refer [root-logger-name]]
+   [schema.core :as s]))
+
+;; Note that the logging configuration is a global resource, so
+;; simultaneous calls to reset-logging, configure-logging!, etc. may
+;; interfere with many of these calls.
+
+(def ^:private keyword-levels
+  {:trace Level/TRACE
+   :debug Level/DEBUG
+   :info Level/INFO
+   :warn Level/WARN
+   :error Level/ERROR})
+
+(def ^:private level-keywords (set/map-invert keyword-levels))
+
+(def ^:private levels (set (keys keyword-levels)))
+
+(defn event->map [event]
+  "Returns {:logger name :level lvl :exception throwable :message msg}
+  for the given event.  Note that this does not convert any nil
+  messages to \"\"."
+  {:logger (.getLoggerName event)
+   :level  (level-keywords (.getLevel event))
+   :message (.getMessage event)
+   :exception (.getThrowableProxy event)})
+
+;; Perhaps make call-with-started and with-started public in
+;; kitchensink or some other namespace?
+
+(defn- call-with-started [objs f]
+  (if-not (seq objs)
+    (f)
+    (let [[obj & remainder] objs]
+      (try
+        (call-with-started remainder f)
+        (finally (.stop obj))))))
+
+(defmacro ^:private with-started
+  "Ensures that if a given name's init form executes without throwing
+  an exception, (.stop name) will be called before returning from
+  with-started.  It is the responsibility of the init form to make
+  sure the object has been started.  This macro behaves like
+  with-open, but with respect to .stop instead of .close."
+  [bindings & body]
+  (let [names (take-nth 2 bindings)
+        initializers (take-nth 2 (rest bindings))]
+    `(let [started-objs# [~@initializers]]
+       (#'puppetlabs.trapperkeeper.testutils.logging/call-with-started
+        started-objs#
+        (fn []
+          (apply (fn [~@names] ~@body) started-objs#))))))
+
+(defn- find-logger [id]
+  (LoggerFactory/getLogger (if (class? id) id (str id))))
+
+(defn call-with-log-level
+  "Sets the (logback) log level for the logger specified by logger-id
+  during the evaluation of f.  If logger-id is not a class, it will be
+  converted via str, and the level must be a clojure.tools.logging
+  key, i.e. :info, :error, etc."
+  [logger-id level f]
+  ;; Assumes use of logback (i.e. logger supports Levels).
+  (let [logger (find-logger logger-id)
+        original-level (.getLevel logger)]
+    (try
+      (.setLevel logger (level keyword-levels))
+      (f)
+      (finally (.setLevel logger original-level)))))
+
+(defmacro with-log-level
+  "Sets the (logback) log level for the logger specified by logger-id
+  during the evaluation of body.  If logger-id is not a class, it will
+  be converted via str, and the level must be a clojure.tools.logging
+  key, i.e. :info, :error, etc."
+  [logger-id level & body]
+  `(call-with-log-level ~logger-id ~level (fn [] ~@body)))
+
+(defn- log-event-listener
+  "Returns a log Appender that will call (listen event) for each log event."
+  [listen]
+  ;; No clue yet if we're supposed to start with a default name.
+  (let [name (atom (str "tk-log-listener-" (kitchensink/uuid)))]
+    (reify
+      Appender
+      (doAppend [this event] (listen event))
+      (getName [this] @name)
+      (setName [this x] (reset! name x))
+      LifeCycle
+      (start [this] true)
+      (stop [this] true))))
+
+(defn call-with-additional-log-appenders [logger-id appenders f]
+  "Adds the specified appenders to the logger specified by logger-id,
+  calls f, and then removes them.  If logger-id is not a class, it
+  will be converted via str."
+  (let [logger (find-logger logger-id)]
+    (try
+      (doseq [appender appenders]
+        (.addAppender logger appender))
+      (f)
+      (finally
+        (doseq [appender appenders]
+          (.detachAppender logger appender))))))
+
+(defmacro with-additional-log-appenders
+  "Adds the specified appenders to the logger specified by logger-id,
+  evaluates body, and then removes them.  If logger-id is not a class,
+  it will be converted via str."
+  [logger-id appenders & body]
+  `(call-with-additional-log-appenders ~logger-id ~appenders (fn [] ~@body)))
+
+(defn call-with-log-appenders [logger-id appenders f]
+  "Replaces the appenders of the logger specified by logger-id with
+  the specified appenders, calls f, and then restores the original
+  appenders.  If logger-id is not a class, it will be converted via
+  str."
+  (let [logger (find-logger logger-id)
+        original-appenders (iterator-seq (.iteratorForAppenders logger))]
+    (try
+      (doseq [appender original-appenders]
+        (.detachAppender logger appender))
+      (call-with-additional-log-appenders logger-id appenders f)
+      (finally
+        (doseq [appender original-appenders]
+          (.addAppender logger appender))))))
+
+(defmacro with-log-appenders
+  "Replaces the appenders of the logger specified by logger-id with
+  the specified appenders, evaluates body, and then restores the
+  original appenders.  If logger-id is not a class, it will be
+  converted via str."
+  [logger-id appenders & body]
+  `(call-with-log-appenders ~logger-id ~appenders (fn [] ~@body)))
+
+(defn call-with-additional-log-event-listeners
+  "For each listen in listens, calls (listen event) for each logger-id
+  event produced during the evaluation of f.  If logger-id is not a
+  class, it will be converted via str."
+  [logger-id listens f]
+  (letfn [(set-up [listens listeners]
+            (if-not (seq listens)
+              (call-with-additional-log-appenders logger-id listeners f)
+              (let [[listen & remainder] listens]
+                (with-started [listener (doto (log-event-listener listen)
+                                          .start)]
+                  (set-up remainder (conj listeners listener))))))]
+    (set-up listens [])))
+
+(defmacro with-additional-log-event-listeners
+  "For each listen in listens, calls (listen event) for each logger-id
+  event produced during the evaluation of body.  If logger-id is not a
+  class, it will be converted via str."
+  [logger-id listens & body]
+  `(call-with-additional-log-event-listeners ~logger-id ~listens
+                                             (fn [] ~@body)))
+
+(defn call-with-log-event-listeners
+  "For each listen in listens, calls (listen event) for each logger-id
+  event produced during the evaluation of f, after removing any
+  existing log appenders.  If logger-id is not a class, it will be
+  converted via str."
+  [logger-id listens f]
+  (letfn [(set-up [listens listeners]
+            (if-not (seq listens)
+              (call-with-log-appenders logger-id listeners f)
+              (let [[listen & remainder] listens]
+                (with-started [listener (doto (log-event-listener listen)
+                                          .start)]
+                  (set-up remainder (conj listeners listener))))))]
+    (set-up listens [])))
+
+(defmacro with-log-event-listeners
+  "For each listen in listens, calls (listen event) for each logger-id
+  event produced during the evaluation of body, after removing any
+  existing log appenders.  If logger-id is not a class, it will be
+  converted via str."
+  [logger-id listens & body]
+  `(call-with-log-event-listeners ~logger-id ~listens (fn [] ~@body)))
+
+(defmacro with-additional-logging-to-atom
+  "Conjoins all logger-id events produced during the evaluation of the
+  body onto the collection in the destination atom.  If logger-id is
+  not a class, it will be converted via str."
+  [logger-id destination & body]
+  `(with-additional-log-event-listeners
+     ~logger-id
+     [(fn [event#] (swap! ~destination conj event#))]
+     ~@body))
+
+(defmacro with-logging-to-atom
+  "Conjoins all logger-id events produced during the evaluation of the
+  body onto the collection in the destination atom, after removing any
+  existing log appenders.  If logger-id is not a class, it will be
+  converted via str."
+  [logger-id destination & body]
+  `(with-log-event-listeners
+     ~logger-id
+     [(fn [event#] (swap! ~destination conj event#))]
+     ~@body))
+
+(defn- suppressing-file-appender
+  [log-path]
+  (let [pattern "%-4relative [%thread] %-5level %logger{35} - %msg%n"
+        context (LoggerFactory/getILoggerFactory)]
+    (doto (FileAppender.)
+      (.setFile log-path)
+      (.setAppend true)
+      (.setEncoder (doto (PatternLayoutEncoder.)
+                     (.setPattern pattern)
+                     (.setContext context)
+                     (.start)))
+      (.setContext context)
+      (.start))))
+
+(defn call-with-log-suppressed-unless-notable [pred f]
+  (let [problem (atom false)
+        log-path (fs/absolute-path (fs/temp-file "tk-suppressed" ".log"))]
+    (try
+      (with-started [appender (suppressing-file-appender log-path)
+                     detector (doto (log-event-listener
+                                     (fn [event]
+                                       (when (pred event)
+                                         (reset! problem true))))
+                                .start)]
+        (with-log-appenders root-logger-name
+          [appender detector]
+          (f)))
+      (finally
+        (if @problem
+          (binding [*out* *err*]
+            (print (slurp log-path))
+            (println "From error log:" log-path))
+          (fs/delete log-path))))))
+
+(defmacro with-log-suppressed-unless-notable
+  "Executes the body with all logging suppressed, and passes every log
+  event to pred.  Dumps the full log to *err* along with its path if,
+  and only if, any invocation of pred returns a true value, .  Assumes
+  that the logging level is already set as desired.  This may not work
+  correctly if the system logback config is altered during the
+  execution of the body."
+  [pred & body]
+  `(call-with-log-suppressed-unless-notable ~pred (fn [] ~@body)))
+
+(def ^{:doc "An atom containing a sequence of all of the log event maps
+             recorded during an evaluation of with-test-logging."
+       :dynamic true
+       :private true}
+  *test-log-events*
+  nil)
+
+(defmacro with-test-logging
+  "Creates an environment for the use of the logged? test method."
+  [& body]
+  `(let [destination# (atom [])]
+     (binding [*test-log-events* destination#]
+       (with-log-level root-logger-name :trace
+         (with-logging-to-atom root-logger-name destination#
+           ~@body)))))
+
+(defmacro with-test-logging-debug
+  "Creates an environment for the use of the logged? test method, and
+  arranges for every event map logged within that environment to be
+  printed to *err*."
+  [& body]
+  `(let [destination# (atom [])]
+     (binding [*test-log-events* destination#]
+       (with-log-level root-logger-name :trace
+         (with-log-event-listeners root-logger-name
+           [(fn [event#]
+              (binding [*out* *err*]
+                (println "** Log entry:" (pr-str (event->map event#))))
+              (swap! destination# conj event#))]
+           ~@body)))))
+
+(s/defn ^{:always-validate true} logged?
+  ([msg-or-pred] (logged? msg-or-pred nil))
+  ([msg-or-pred :- (s/conditional ifn? (s/pred ifn?)
+                                  string? s/Str
+                                  :else Pattern)
+    maybe-level :- (s/maybe (s/pred #(levels %)))]
+   (let [match? (cond (ifn? msg-or-pred) msg-or-pred
+                      (string? msg-or-pred) #(= msg-or-pred (:message %))
+                      :else #(re-find msg-or-pred (:message %)))
+         one-element? #(and (seq %) (empty? (rest %)))]
+     (one-element? (filter match? (map event->map @*test-log-events*))))))
+
+(defmethod clojure.test/assert-expr 'logged? [is-msg form]
+  "Asserts that exactly one event in *test-log-events* has a message
+  that matches msg-or-pred.  The match is performed via = if
+  msg-or-pred is a string, via re-find if msg-or-pred is a pattern, or
+  via (msg-or-pred event-map) if msg-or-pred is a function.  If level
+  is specified, the message's keyword level (:info, :error, etc.) must
+  also match.  For example:
+    (with-test-logging (log/info \"123\") (is (logged? #\"2\")))."
+  (assert (#{2 3} (count form)))
+  (let [[_ msg-or-pred level] form]
+    `(let [events# @@#'puppetlabs.trapperkeeper.testutils.logging/*test-log-events*]
+       (if-not (logged? ~msg-or-pred ~level)
+         (clojure.test/do-report
+          {:type :fail
+           :message ~is-msg
+           :expected '~form
+           :actual (list '~'logged events#)})
+         (clojure.test/do-report
+          {:type :pass
+           :message ~is-msg
+           :expected '~form
+           :actual (list '~'logged events#)})))))
+
+(defn reset-logging-config-after-test
+  "Fixture that will reset the logging configuration after each
+  test.  Useful for tests that manipulate the logging configuration,
+  in order to ensure that they don't affect test logging for subsequent
+  tests."
+  [f]
+  (f)
+  (pl-log/reset-logging))
+
+
+;;; Deprecated API (clojure.tools.logging specific, etc.)
 
 (def ^{:doc "A dynamic var that is bound to an atom containing all of the log entries
              that have occurred during a test, when using `with-test-logging`."
-       :dynamic true}
+       :dynamic true
+       :deprecated "1.1.2"}
   *test-logs*
   nil)
 
-(def legal-levels #{nil :trace :debug :info :warn :error :fatal})
+(def ^{:deprecated "1.1.2"} legal-levels
+  #{nil :trace :debug :info :warn :error :fatal})
 
-(defn- log-entry->map
+(defn- ^{:deprecated "1.1.2"} log-entry->map
   [log-entry]
   {:namespace (get log-entry 0)
    :level     (get log-entry 1)
    :exception (get log-entry 2)
    :message   (get log-entry 3)})
 
-(defn logs-matching
+(defn ^{:deprecated "1.1.2"} logs-matching
   "Given a regular expression pattern, a sequence of log messages (in the format
   used by `clojure.tools.logging`, and (optionally) a log level (as a keyword
   that corresponds to those in `clojure.tools.logging`) return only the logs
@@ -44,16 +377,21 @@
          matches (filter #(and (matches-level? %) (matches-msg? %)) logs)]
      (map log-entry->map matches))))
 
-(defn log-to-console
+(defn ^{:deprecated "1.1.2"} log-to-console
   "Utility function called by atom-logger and atom-appender to log entries to the
   console when running in debug mode."
   [entry]
   (println "** Log entry:" entry))
 
-(defn atom-logger
-  "A logger factory that logs output to the supplied atom"
-  ([output-atom] (atom-logger output-atom false))
-  ([output-atom debug]
+(defn ^{:deprecated "1.1.2"} atom-logger
+  "Returns a logger factory that returns loggers that conjoin each log
+  event onto the collection in the destination atom, and that also
+  invoke (log-to-console event) if debug? is true.  This will only
+  capture events logged by clojure.tools.logging, and the events will
+  be vectors like this [namespace level exception message].  Prefer
+  with-logging-to-atom."
+  ([destination] (atom-logger destination false))
+  ([destination debug?]
    (reify impl/LoggerFactory
      (name [_] "test factory")
      (get-logger [_ log-ns]
@@ -61,14 +399,17 @@
          (enabled? [_ level] true)
          (write! [_ lvl ex msg]
            (let [entry [(str log-ns) lvl ex msg]]
-             (when debug (log-to-console entry))
-             (swap! output-atom conj entry)
+             (when debug? (log-to-console entry))
+             (swap! destination conj entry)
              nil)))))))
 
-(defn atom-appender
-  "Creates a logback appender that writes log messages to the supplied atom"
-  ([output-atom] (atom-appender output-atom false))
-  ([output-atom debug]
+(defn ^{:deprecated "1.1.2"} atom-appender
+  "Returns a log Appender that conjoins each log event to the
+  collection in the destination atom, and that also
+  invokes (log-to-console event) if debug? is true.  Prefer
+  with-logging-to-atom."
+  ([destination] (atom-appender destination false))
+  ([destination debug?]
    (let [appender (proxy [AppenderBase] []
                     (append [logging-event]
                        (let [throwable-info (.getThrowableInformation logging-event)
@@ -77,13 +418,13 @@
                                     (.getLevel logging-event)
                                     ex
                                     (str (.getMessage logging-event))]]
-                         (when debug (log-to-console entry))
-                         (swap! output-atom conj entry)))
+                         (when debug? (log-to-console entry))
+                         (swap! destination conj entry)))
                      (close []))]
      (.setContext appender (pl-log/logging-context))
      appender)))
 
-(defmacro with-log-output-atom
+(defmacro ^{:deprecated "1.1.2"} with-log-output-atom
   "This is a utility macro, intended for use by other macros such as
   `with-test-logging`.
 
@@ -92,7 +433,9 @@
 
   `log-output-atom` - Inside of `body`, this atom will be used to store
   the sequence of log messages that have been logged so far.  You can access the
-  individual log messages by dereferencing the atom."
+  individual log messages by dereferencing the atom.
+
+  Prefer with-logging-to-atom."
   [log-output-atom options & body]
   `(let [root-logger#     (pl-log/root-logger)
          orig-appenders#  (vec (iterator-seq (.iteratorForAppenders root-logger#)))
@@ -114,7 +457,7 @@
            (if (orig-started# orig-appender#)
              (.start orig-appender#)))))))
 
-(defmacro with-log-output
+(defmacro ^{:deprecated "1.1.2"} with-log-output
   "Sets up a temporary logger to capture all log output to a sequence, and
   evaluates `body` in this logging context.
 
@@ -131,78 +474,3 @@
   [log-output-var & body]
   `(let [~log-output-var  (atom [])]
      (with-log-output-atom ~log-output-var {:debug false} ~@body)))
-
-(defmacro with-test-logging
-  "Executes `body` in a context in which all log messages are captured and
-  available to write test assertions against, using the `logged?` assertion
-  expression.  Example:
-
-      (with-test-logging
-        (log/info \"hi\")
-        (is (logged? #\"^hi$\"))
-        (is (logged? #\"^hi$\" :info)))"
-  [& body]
-  `(let [test-logs# (atom [])]
-     (binding [puppetlabs.trapperkeeper.testutils.logging/*test-logs* test-logs#]
-       (with-log-output-atom test-logs# {:debug false} ~@body))))
-
-(defmacro with-test-logging-debug
-  "This macro is the same as `with-test-logging`, except that it will also cause
-  all log entries to be printed to the console during the test run.  It is
-  only intended for debugging while developing tests that use `with-test-logging`."
-  [& body]
-  `(let [test-logs# (atom [])]
-     (binding [puppetlabs.trapperkeeper.testutils.logging/*test-logs* test-logs#]
-       (with-log-output-atom test-logs# {:debug true} ~@body))))
-
-(defmethod clojure.test/assert-expr 'logged? [msg form]
-  "This is an assertion expression for use with `clojure.test/is`.  It
-  must be used inside a call to `with-test-logging`.  Asserts
-  that exactly one log message occurred during the test which matches
-  the specified pattern and log level.
-
-  Legal log levels correspond to those of `clojure.tools.logging`:
-
-      :trace :debug :info :warn :error :fatal
-
-  Example:
-
-      (with-test-logging
-        (log/info \"hi\")
-        (is (logged? #\"^hi$\"))
-        (is (logged? #\"^hi$\" :info)))"
-  (let [pattern       (nth form 1)
-        level         (nth form 2 nil)
-        debug-msg     "; `with-test-logging-debug` may be useful for debugging tests."]
-    (when-not (instance? Pattern pattern)
-      (throw (IllegalArgumentException.
-               "First argument to `logged?` must be a java.util.regex.Pattern")))
-    (when-not (contains? legal-levels level)
-      (throw (IllegalArgumentException.
-               (str "Optional second argument to `logged?` must be one of "
-                    legal-levels "; illegal value: '" level "'"))))
-    `(let [logs#    @puppetlabs.trapperkeeper.testutils.logging/*test-logs*
-           matches# (logs-matching ~pattern logs# ~level)]
-       (if-not (= 1 (count matches#))
-         (clojure.test/do-report
-           {:type      :fail
-            :message   ~msg
-            :expected  (str "Exactly one log message matching the pattern '"
-                            ~pattern "'"
-                            (when ~level (format " at '%s' level" (name ~level))))
-            :actual    (str (count matches#) " matches" ~debug-msg)})
-
-         (clojure.test/do-report
-           {:type      :pass
-            :message   ~msg
-            :expected  '~form
-            :actual    '~form})))))
-
-(defn reset-logging-config-after-test
-  "Fixture that will reset the logging configuration after each
-  test.  Useful for tests that manipulate the logging configuration,
-  in order to ensure that they don't affect test logging for subsequent
-  tests."
-  [f]
-  (f)
-  (pl-log/reset-logging))

--- a/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
@@ -1,0 +1,150 @@
+(ns puppetlabs.trapperkeeper.testutils.logging-test
+  (:require
+   [clojure.test :refer :all]
+   [clojure.tools.logging :as log]
+   [puppetlabs.kitchensink.core :as kitchensink]
+   [puppetlabs.trapperkeeper.logging :refer [reset-logging root-logger-name]]
+   [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]])
+  (:import
+   [org.slf4j Logger LoggerFactory]))
+
+;; Without this, "lein test NAMESPACE" and :only invocations may fail.
+(use-fixtures :once (fn [f] (reset-logging) (f)))
+
+(deftest with-log-level-and-logging-to-atom
+  (let [expected {:logger "puppetlabs.trapperkeeper.testutils.logging-test"
+                  :level :info
+                  :message "wlta-test"
+                  :exception nil}]
+    (let [log (atom [])]
+      (tgt/with-log-level root-logger-name :error
+        (tgt/with-logging-to-atom root-logger-name log
+          (log/info "wlta-test"))
+        (is (not-any? #(= expected %) (map event->map @log)))))
+    (let [log (atom [])]
+      (tgt/with-log-level root-logger-name :info
+        (tgt/with-logging-to-atom root-logger-name log
+          (log/info "wlta-test"))
+        (is (some #(= expected %) (map event->map @log)))))))
+
+(def find-logger #'puppetlabs.trapperkeeper.testutils.logging/find-logger)
+(def log-event-listener #'puppetlabs.trapperkeeper.testutils.logging/log-event-listener)
+
+(defn get-appenders [logger]
+  (iterator-seq (.iteratorForAppenders logger)))
+
+(deftest with-additional-log-appenders
+  (let [log (atom [])
+        logger (find-logger root-logger-name)
+        uuid (kitchensink/uuid)
+        original-appenders (get-appenders logger)
+        new-appender (log-event-listener (fn [event] (swap! log conj event)))
+        expected {:logger "puppetlabs.trapperkeeper.testutils.logging-test"
+                  :level :error
+                  :message uuid
+                  :exception nil}]
+    (tgt/with-additional-log-appenders root-logger-name [new-appender]
+      (is (= (set (cons new-appender original-appenders))
+             (set (get-appenders logger))))
+      (log/error uuid))
+    (is (= (set original-appenders)
+           (set (get-appenders logger))))
+    (is (some #(= expected %) (map event->map @log)))))
+
+(deftest with-log-appenders
+  (let [log (atom [])
+        logger (find-logger root-logger-name)
+        uuid (kitchensink/uuid)
+        original-appenders (get-appenders logger)
+        new-appender (log-event-listener (fn [event] (swap! log conj event)))
+        expected {:logger "puppetlabs.trapperkeeper.testutils.logging-test"
+                  :level :error
+                  :message uuid
+                  :exception nil}]
+    (tgt/with-log-appenders root-logger-name
+      [new-appender]
+      (is (= [new-appender] (get-appenders logger)))
+      (log/error uuid))
+    (is (= (set original-appenders)
+           (set (get-appenders logger))))
+    (is (some #(= expected %) (map event->map @log)))))
+
+(deftest with-log-event-listeners
+  (let [log (atom [])
+        uuid (kitchensink/uuid)
+        expected {:logger "puppetlabs.trapperkeeper.testutils.logging-test"
+                  :level :info
+                  :message uuid
+                  :exception nil}]
+    (tgt/with-log-level root-logger-name :info
+      (tgt/with-log-event-listeners root-logger-name
+        [(fn [event] (swap! log conj event))]
+        (log/info uuid))
+      (is (some #(= expected %) (map event->map @log))))))
+
+(deftest suppressing-log-unless-error
+  (let [uuid (kitchensink/uuid)
+        target (format "some random message %s" uuid)]
+    (testing "log not dumped if uninteresting"
+      (is (not (re-find (re-pattern target)
+                        (with-out-str
+                          (binding [*err* *out*]
+                            (tgt/with-log-suppressed-unless-notable
+                              (constantly false)
+                              (log/info target))))))))
+    (testing "log dumped if notable"
+      (is (re-find (re-pattern target)
+                   (with-out-str
+                     (binding [*err* *out*]
+                       (tgt/with-log-suppressed-unless-notable
+                         #(= "lp0 on fire" (:message (event->map %)))
+                         (log/info target)
+                         (log/info "lp0 on fire")))))))))
+
+(deftest with-test-logging
+  (testing "basic matching"
+    (doseq [[item test] [["foo" "foo"
+                          "barbar" #"rb"
+                          "baz" (fn [e]
+                                  (and (= :trace (:level e))
+                                       (= "baz" (:message e))))]]]
+      (tgt/with-test-logging
+        (log/trace item)
+        (is (logged? test)))
+      (tgt/with-test-logging
+        (log/trace "hapax legomenon")
+        (is (not (tgt/logged? test))))))
+  (testing "level matches"
+    (doseq [level @#'puppetlabs.trapperkeeper.testutils.logging/levels]
+      (tgt/with-test-logging
+        (log/log level "foo")
+        (is (logged? "foo" level))))))
+
+(deftest with-test-logging-debug
+  (testing "basic matching"
+    (doseq [[item test] [["foo" "foo"
+                          "barbar" #"rb"
+                          "baz" (fn [e]
+                                  (and (= :trace (:level e))
+                                       (= "baz" (:message e))))]]]
+      (tgt/with-test-logging-debug
+        (log/trace item)
+        (is (logged? test)))
+      (tgt/with-test-logging-debug
+        (log/trace "hapax legomenon")
+        (is (not (tgt/logged? test))))))
+  (testing "level matches"
+    (doseq [level @#'puppetlabs.trapperkeeper.testutils.logging/levels]
+      (tgt/with-test-logging-debug
+        (log/log level "foo")
+        (is (logged? "foo" level)))))
+  (testing "that events are logged to *err*"
+    (tgt/with-test-logging-debug
+      (let [err (with-out-str (binding [*err* *out*]
+                                (log/trace "foo")))]
+        (is (re-matches #"\*\* Log entry: (.|\n)*" err))
+        (is (re-find #":logger " err))
+        (is (re-find #":level :trace" err))
+        (is (re-find #":exception nil" err))
+        (is (re-find #":message \"foo\"" err)))
+      (is (logged? "foo")))))

--- a/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
@@ -4,9 +4,7 @@
    [clojure.tools.logging :as log]
    [puppetlabs.kitchensink.core :as kitchensink]
    [puppetlabs.trapperkeeper.logging :refer [reset-logging root-logger-name]]
-   [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]])
-  (:import
-   [org.slf4j Logger LoggerFactory]))
+   [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]]))
 
 ;; Without this, "lein test NAMESPACE" and :only invocations may fail.
 (use-fixtures :once (fn [f] (reset-logging) (f)))


### PR DESCRIPTION
Rework testutils.logging to tie in at the logback (Java) level, rather
than the clojure.tools.logging level, allowing us to see and manipulate
most, if not all log events.

Have the core API handle only native event objects for efficiency, but
provide a more friendly map representation via event->map.

Add a set of scoped call-with-* and with-* handlers to allow temporarily
overriding the logging appenders, level, etc.

Rework the existing with-test-logging, with-test-logging-debug, and
logged? code to use the new API, add some tests, and add some minor new,
backward-compatible features.  Using the new API does change the
fundamental semantics a bit, since logged? may see more events than it
used to (perhaps from ActiveMQ or...), but that seems unlikely to break
existing tests unless the the selectors weren't specific enough to begin
with, and is easily fixed.

Add a new with-log-suppressed-unless-notable macro that suppresses all
logging unless an event matches its notable-event? predicate, in which
case it will dump the log to *err* and provide a path to the temporary
log file.

Deprecate much of the previous code, which should for the most part be
superceded by the new calls.

cf. PDB-1995

[This began as PuppetDB 5a4789fcd3a82514a335ab59735965ef0d2a6e59]