### PR TITLE
(TK-202) Add support for restart and HUP handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
                  [org.codehaus.janino/janino "2.7.8"]
                  [puppetlabs/typesafe-config "0.1.1"]
                  [me.raynes/fs "1.4.5"]
-                 [clj-yaml "0.4.0"]]
+                 [clj-yaml "0.4.0"]
+                 [beckon "0.1.1"]]
 
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}

--- a/src/puppetlabs/trapperkeeper/app.clj
+++ b/src/puppetlabs/trapperkeeper/app.clj
@@ -12,4 +12,5 @@
                                  "occurred, return the input parameter."))
   (init [this] "Initialize the services")
   (start [this] "Start the services")
-  (stop [this] "Stop the services"))
+  (stop [this] "Stop the services")
+  (restart [this] "Stop and restart the services"))

--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -32,13 +32,14 @@
   (`init`, `start`, `stop`) as you see fit;  if you'd like to have the trapperkeeper
   framework block the main thread to wait for a shutdown event, call `init`,
   `start`, and then `run-app`."
-  [services config-data-fn]
+  [services config-data]
   {:pre  [(sequential? services)
           (every? #(satisfies? services/ServiceDefinition %) services)
-          (ifn? config-data-fn)]
+          (ifn? config-data)]
    :post [(satisfies? app/TrapperkeeperApp %)]}
-  (config/initialize-logging! (config-data-fn))
-  (internal/build-app* services config-data-fn (promise)))
+  (let [config-data-fn (if (map? config-data) (constantly config-data) config-data)]
+    (config/initialize-logging! (config-data-fn))
+    (internal/build-app* services config-data-fn (promise))))
 
 (defn boot-services-with-cli-data
   "Given a list of ServiceDefinitions and a map containing parsed cli data, create

--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -114,13 +114,6 @@
         (bootstrap/parse-bootstrap-config!)
         (internal/boot-services* config-data))))
 
-
-;; This variable is used to hold a reference to the "main" trapperkeeper
-;; application instance if you use trapperkeeper's "main" function to
-;; launch your application.  This allows you to get a reference to the
-;; app in a remote nREPL session if you are using the nrepl service.
-(def main-app nil)
-
 (defn run-app
   "Given a bootstrapped TrapperKeeper app, let the application run until shut down,
   which may be triggered by one of several different ways. In all cases, services
@@ -144,7 +137,7 @@
   (let [app (boot-with-cli-data cli-data)]
     ;; This line populates the `main-app` variable with the TrapperkeeperApp
     ;; instance.  This allows it to be referenced in a remote nREPL session.
-    (alter-var-root #'main-app (fn [_] app))
+    (swap! internal/tk-apps conj app)
     (run-app app)))
 
 (defn main

--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -138,6 +138,7 @@
     ;; This adds the TrapperkeeperApp instance to the tk-apps list, so that
     ;; it can be referenced in a remote nREPL session, etc.
     (swap! internal/tk-apps conj app)
+    (internal/register-sighup-handler)
     (run-app app)
     (swap! internal/tk-apps (partial remove #{app}))))
 

--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -135,10 +135,11 @@
   [cli-data]
   {:pre [(map? cli-data)]}
   (let [app (boot-with-cli-data cli-data)]
-    ;; This line populates the `main-app` variable with the TrapperkeeperApp
-    ;; instance.  This allows it to be referenced in a remote nREPL session.
+    ;; This adds the TrapperkeeperApp instance to the tk-apps list, so that
+    ;; it can be referenced in a remote nREPL session, etc.
     (swap! internal/tk-apps conj app)
-    (run-app app)))
+    (run-app app)
+    (swap! internal/tk-apps (partial remove #{app}))))
 
 (defn main
   "Launches the trapperkeeper framework. This function blocks until

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -478,6 +478,7 @@
         this)
       (a/restart [this]
         (run-lifecycle-fns app-context s/stop "stop" (reverse ordered-services))
+        (doseq [svc-id (keys services-by-id)] (swap! app-context assoc svc-id {}))
         (run-lifecycle-fns app-context s/init "init" ordered-services)
         (run-lifecycle-fns app-context s/start "start" ordered-services)))))
 

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -8,6 +8,8 @@
             [puppetlabs.trapperkeeper.services :as s]
             [puppetlabs.kitchensink.core :as ks]))
 
+(def tk-apps (atom []))
+
 (defn service-graph?
   "Predicate that tests whether or not the argument is a valid trapperkeeper
   service graph."

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.internal
   (:import (clojure.lang Atom ExceptionInfo))
   (:require [clojure.tools.logging :as log]
+            [beckon]
             [plumbing.graph :as graph]
             [puppetlabs.kitchensink.core :refer [add-shutdown-hook! boolean? cli!]]
             [puppetlabs.trapperkeeper.config :refer [config-service]]
@@ -191,6 +192,26 @@
     (catch Throwable t
       (log/errorf t "Error during service %s!!!" lifecycle-fn-name)
       (throw t))))
+
+(def ^:private sighup-lock (Object.))
+
+(defn restart-tk-apps
+  "Call restart on all tk apps."
+  [apps]
+  (log/debug "SIGHUP handler restarting TK apps.")
+  (locking sighup-lock
+    (doseq [app apps]
+      (a/restart app))))
+
+(defn register-sighup-handler
+  "Register a handler for SIGHUP that restarts all trapperkeeper apps. The
+  default handler terminates the process, so we always overwrite that. This
+  function is idempotent."
+  ([]
+   (register-sighup-handler @tk-apps))
+  ([apps]
+   (log/debug "Registering SIGHUP handler for restarting TK apps")
+   (reset! (beckon/signal-atom "HUP") #{(partial restart-tk-apps apps)})))
 
 ;;;; Application Shutdown Support
 ;;;;

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -482,6 +482,7 @@
           (doseq [svc-id (keys services-by-id)] (swap! app-context assoc svc-id {}))
           (run-lifecycle-fns app-context s/init "init" ordered-services)
           (run-lifecycle-fns app-context s/start "start" ordered-services)
+          this
           (catch Throwable t
             (deliver shutdown-reason-promise {:cause :service-error
                                               :error t})))))))

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -448,7 +448,11 @@
         this)
       (a/stop [this]
         (shutdown! app-context)
-        this))))
+        this)
+      (a/restart [this]
+        (run-lifecycle-fns app-context s/stop "stop" (reverse ordered-services))
+        (run-lifecycle-fns app-context s/init "init" ordered-services)
+        (run-lifecycle-fns app-context s/start "start" ordered-services)))))
 
 (defn boot-services*
   "Given the services to run and the map of configuration data, create the

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -8,6 +8,10 @@
             [puppetlabs.trapperkeeper.services :as s]
             [puppetlabs.kitchensink.core :as ks]))
 
+;; This is (eww) a global variable that holds a reference to all of the running
+;; Trapperkeeper apps in the process. It can be used when connecting via nrepl
+;; to allow you to do useful things, and also may be used for other things
+;; (such as signal handling).
 (def tk-apps (atom []))
 
 (defn service-graph?

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -10,7 +10,7 @@
             [puppetlabs.kitchensink.testutils.fixtures :refer [with-no-jvm-shutdown-hooks]]
             [beckon]
             [puppetlabs.trapperkeeper.internal :as internal]
-            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging with-test-logging-debug]]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.kitchensink.testutils :as ks-testutils])
   (:import (java.util.concurrent ExecutionException)))

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -149,8 +149,8 @@
         (internal/register-sighup-handler [app])
         (beckon/raise! "HUP")
         (let [start (System/currentTimeMillis)]
-          (while (or (not= (count @call-seq) 15)
-                     (> (- (System/currentTimeMillis) start) 1000))
+          (while (and (not= (count @call-seq) 15)
+                     (< (- (System/currentTimeMillis) start) 1000))
             (Thread/yield)))
         (is (= (count @call-seq) 15))
         (is (= [:init-service1 :init-service2 :init-service3

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -171,17 +171,17 @@
   (testing "service-id should be able to be called from any lifecycle phase"
     (let [test-context (atom {})
           service1 (service Service1
-                            []
-                            (init [this context]
-                                  (swap! test-context assoc :init-service-id (svcs/service-id this))
-                                  context)
-                            (start [this context]
-                                   (swap! test-context assoc :start-service-id (svcs/service-id this))
-                                   context)
-                            (stop [this context]
-                                  (swap! test-context assoc :stop-service-id (svcs/service-id this))
-                                  context)
-                            (service1-fn [this] nil))]
+                     []
+                     (init [this context]
+                           (swap! test-context assoc :init-service-id (svcs/service-id this))
+                           context)
+                     (start [this context]
+                            (swap! test-context assoc :start-service-id (svcs/service-id this))
+                            context)
+                     (stop [this context]
+                           (swap! test-context assoc :stop-service-id (svcs/service-id this))
+                           context)
+                     (service1-fn [this] nil))]
       (with-app-with-empty-config app [service1]
         ;; no-op; we just want the app to start up and shut down
         )
@@ -192,25 +192,25 @@
 (deftest dependencies-test
   (testing "services should be able to call functions in dependency list"
     (let [service1 (service Service1
-                            []
-                            (service1-fn [this] "FOO!"))
+                     []
+                     (service1-fn [this] "FOO!"))
           service2 (service Service2
-                            [[:Service1 service1-fn]]
-                            (service2-fn [this] (str "HELLO " (service1-fn))))
+                     [[:Service1 service1-fn]]
+                     (service2-fn [this] (str "HELLO " (service1-fn))))
           app (bootstrap-services-with-empty-config [service1 service2])
           s2  (app/get-service app :Service2)]
       (is (= "HELLO FOO!" (service2-fn s2)))))
 
   (testing "services should be able to retrieve instances of services that they depend on"
     (let [service1 (service Service1
-                            []
-                            (service1-fn [this] "FOO!"))
+                     []
+                     (service1-fn [this] "FOO!"))
           service2 (service Service2
-                            [[:Service1 service1-fn]]
-                            (init [this context]
-                                  (let [s1 (svcs/get-service this :Service1)]
-                                    (assoc context :s1 s1)))
-                            (service2-fn [this] ((svcs/service-context this) :s1)))
+                     [[:Service1 service1-fn]]
+                     (init [this context]
+                           (let [s1 (svcs/get-service this :Service1)]
+                             (assoc context :s1 s1)))
+                     (service2-fn [this] ((svcs/service-context this) :s1)))
           app               (bootstrap-services-with-empty-config [service1 service2])
           s2                (app/get-service app :Service2)
           s1                (service2-fn s2)]
@@ -219,23 +219,23 @@
 
   (testing "an error should be thrown if calling get-service on a non-existent service"
     (let [service1 (service Service1
-                            []
-                            (service1-fn [this] (svcs/get-service this :NonExistent)))
+                     []
+                     (service1-fn [this] (svcs/get-service this :NonExistent)))
           app               (bootstrap-services-with-empty-config [service1])
           s1                (app/get-service app :Service1)]
       (is (thrown-with-msg?
-            IllegalArgumentException
-            #"Call to 'get-service' failed; service ':NonExistent' does not exist."
-            (service1-fn s1)))))
+           IllegalArgumentException
+           #"Call to 'get-service' failed; service ':NonExistent' does not exist."
+           (service1-fn s1)))))
 
   (testing "lifecycle functions should be able to call injected functions"
     (let [service1 (service Service1
-                            []
-                            (service1-fn [this] "FOO!"))
+                     []
+                     (service1-fn [this] "FOO!"))
           service2 (service Service2
-                            [[:Service1 service1-fn]]
-                            (init [this context] (service1-fn) context)
-                            (service2-fn [this] "service2"))
+                     [[:Service1 service1-fn]]
+                     (init [this context] (service1-fn) context)
+                     (service2-fn [this] "service2"))
           app (bootstrap-services-with-empty-config [service1 service2])
           s2  (app/get-service app :Service2)]
       (is (= "service2" (service2-fn s2))))))
@@ -269,61 +269,61 @@
 (deftest context-test
   (testing "should error if lifecycle function doesn't return context"
     (is (thrown-with-msg?
-          IllegalStateException
-          (re-pattern (str "Lifecycle function 'init' for service "
-                           "'puppetlabs.trapperkeeper.services-test/service1'"
-                           " must return a context map \\(got: \"hi\"\\)"))
-          (bootstrap-services-with-empty-config [service1]))
+         IllegalStateException
+         (re-pattern (str "Lifecycle function 'init' for service "
+                          "'puppetlabs.trapperkeeper.services-test/service1'"
+                          " must return a context map \\(got: \"hi\"\\)"))
+         (bootstrap-services-with-empty-config [service1]))
         "Unexpected shutdown reason for bootstrap")
     (is (thrown-with-msg?
-          IllegalStateException
-          (re-pattern (str "Lifecycle function 'start' for service "
-                           "'puppetlabs.trapperkeeper.services-test/service1-alt'"
-                           " must return a context map "
-                           "\\(got: \"hi\"\\)"))
-          (bootstrap-services-with-empty-config [service1-alt]))
+         IllegalStateException
+         (re-pattern (str "Lifecycle function 'start' for service "
+                          "'puppetlabs.trapperkeeper.services-test/service1-alt'"
+                          " must return a context map "
+                          "\\(got: \"hi\"\\)"))
+         (bootstrap-services-with-empty-config [service1-alt]))
         "Unexpected shutdown reason for bootstrap"))
 
   (testing "lifecycle error works if service has no service symbol"
     (let [service1 (service Service1
-                            []
-                            (init [this context] "hi")
-                            (service1-fn [this] "hi"))]
+                     []
+                     (init [this context] "hi")
+                     (service1-fn [this] "hi"))]
       (is (thrown-with-msg?
-            IllegalStateException
-            (re-pattern (str "Lifecycle function 'init' for service ':Service1'"
-                             " must return a context map \\(got: \"hi\"\\)"))
-            (bootstrap-services-with-empty-config [service1]))
+           IllegalStateException
+           (re-pattern (str "Lifecycle function 'init' for service ':Service1'"
+                            " must return a context map \\(got: \"hi\"\\)"))
+           (bootstrap-services-with-empty-config [service1]))
           "Unexpected shutdown reason for bootstrap"))
     (let [service1 (service Service1
-                            []
-                            (start [this context] "hi")
-                            (service1-fn [this] "hi"))]
+                     []
+                     (start [this context] "hi")
+                     (service1-fn [this] "hi"))]
 
       (is (thrown-with-msg?
-            IllegalStateException
-            (re-pattern (str "Lifecycle function 'start' for service "
-                             "':Service1' must return a context map "
-                             "\\(got: \"hi\"\\)"))
-            (bootstrap-services-with-empty-config [service1]))
+           IllegalStateException
+           (re-pattern (str "Lifecycle function 'start' for service "
+                            "':Service1' must return a context map "
+                            "\\(got: \"hi\"\\)"))
+           (bootstrap-services-with-empty-config [service1]))
           "Unexpected shutdown reason for bootstrap")))
 
   (testing "context should be available in subsequent lifecycle functions"
     (let [start-context (atom nil)
           service1 (service Service1
-                            []
-                            (init [this context] (assoc context :foo :bar))
-                            (start [this context] (reset! start-context context))
-                            (service1-fn [this] "hi"))]
+                     []
+                     (init [this context] (assoc context :foo :bar))
+                     (start [this context] (reset! start-context context))
+                     (service1-fn [this] "hi"))]
       (bootstrap-services-with-empty-config [service1])
       (is (= {:foo :bar} @start-context))))
 
   (testing "context should be accessible in service functions"
     (let [sfn-context (atom nil)
           service1 (service Service1
-                            []
-                            (init [this context] (assoc context :foo :bar))
-                            (service1-fn [this] (reset! sfn-context (svcs/service-context this))))
+                     []
+                     (init [this context] (assoc context :foo :bar))
+                     (service1-fn [this] (reset! sfn-context (svcs/service-context this))))
           app (bootstrap-services-with-empty-config [service1])
           s1  (app/get-service app :Service1)]
       (service1-fn s1)
@@ -332,22 +332,22 @@
 
   (testing "context works correctly in injected functions"
     (let [service1 (service Service1
-                            []
-                            (init [this context] (assoc context :foo :bar))
-                            (service1-fn [this] ((svcs/service-context this) :foo)))
+                     []
+                     (init [this context] (assoc context :foo :bar))
+                     (service1-fn [this] ((svcs/service-context this) :foo)))
           service2 (service Service2
-                            [[:Service1 service1-fn]]
-                            (service2-fn [this] (service1-fn)))
+                     [[:Service1 service1-fn]]
+                     (service2-fn [this] (service1-fn)))
           app (bootstrap-services-with-empty-config [service1 service2])
           s2  (app/get-service app :Service2)]
       (is (= :bar (service2-fn s2)))))
 
   (testing "context works correctly in service functions called by other functions in same service"
     (let [service4 (service Service4
-                            []
-                            (init [this context] (assoc context :foo :bar))
-                            (service4-fn1 [this] ((svcs/service-context this) :foo))
-                            (service4-fn2 [this] (service4-fn1 this)))
+                     []
+                     (init [this context] (assoc context :foo :bar))
+                     (service4-fn1 [this] ((svcs/service-context this) :foo))
+                     (service4-fn2 [this] (service4-fn1 this)))
           app (bootstrap-services-with-empty-config [service4])
           s4  (app/get-service app :Service4)]
       (is (= :bar (service4-fn2 s4)))))
@@ -355,13 +355,13 @@
   (testing "context from other services should not be visible"
     (let [s2-context (atom nil)
           service1 (service Service1
-                            []
-                            (init [this context] (assoc context :foo :bar))
-                            (service1-fn [this] "hi"))
+                     []
+                     (init [this context] (assoc context :foo :bar))
+                     (service1-fn [this] "hi"))
           service2 (service Service2
-                            [[:Service1 service1-fn]]
-                            (start [this context] (reset! s2-context (svcs/service-context this)))
-                            (service2-fn [this] "hi"))
+                     [[:Service1 service1-fn]]
+                     (start [this context] (reset! s2-context (svcs/service-context this)))
+                     (service2-fn [this] "hi"))
 
           app (bootstrap-services-with-empty-config [service1 service2])]
       (is (= {} @s2-context)))))
@@ -396,27 +396,27 @@
   (testing "minimal services can be defined without a protocol"
     (let [call-seq (atom [])
           service0 (service []
-                            (init [this context]
-                                  (swap! call-seq conj :init)
-                                  (assoc context :foo :bar))
-                            (start [this context]
-                                   (swap! call-seq conj :start)
-                                   (is (= context {:foo :bar}))
-                                   context))]
+                     (init [this context]
+                           (swap! call-seq conj :init)
+                           (assoc context :foo :bar))
+                     (start [this context]
+                            (swap! call-seq conj :start)
+                            (is (= context {:foo :bar}))
+                            context))]
       (bootstrap-services-with-empty-config [service0])
       (is (= [:init :start] @call-seq))))
 
   (testing "minimal services can have dependencies"
     (let [service1 (service Service1
-                            []
-                            (service1-fn [this] "hi"))
+                     []
+                     (service1-fn [this] "hi"))
           result   (atom nil)
           service0 (service [[:Service1 service1-fn]]
-                            (init [this context]
-                                  (reset! result (service1-fn))
-                                  context))]
-          (bootstrap-services-with-empty-config [service1 service0])
-          (is (= "hi" @result)))))
+                     (init [this context]
+                           (reset! result (service1-fn))
+                           context))]
+      (bootstrap-services-with-empty-config [service1 service0])
+      (is (= "hi" @result)))))
 
 (defprotocol MultiArityService
   (foo [this x] [this x y]))
@@ -424,13 +424,13 @@
 (deftest test-multi-arity-protocol-fn
   (testing "should support protocols with multi-arity fns"
     (let [ma-service  (service MultiArityService
-                               []
-                               (foo [this x] x)
-                               (foo [this x y] (+ x y)))
+                        []
+                        (foo [this x] x)
+                        (foo [this x y] (+ x y)))
           service1    (service Service1
-                               [[:MultiArityService foo]]
-                               (service1-fn [this]
-                                            [(foo 5) (foo 3 6)]))
+                        [[:MultiArityService foo]]
+                        (service1-fn [this]
+                                     [(foo 5) (foo 3 6)]))
           app         (bootstrap-services-with-empty-config [ma-service service1])
           mas         (app/get-service app :MultiArityService)
           s1          (app/get-service app :Service1)]
@@ -441,11 +441,11 @@
 (deftest service-fn-invalid-docstring
   (testing "defining a service function, mistakenly adding a docstring"
     (is (thrown-with-msg?
-          Exception
-          #"Incorrect macro usage"
-          (macroexpand '(puppetlabs.trapperkeeper.services/service
-                          puppetlabs.trapperkeeper.services-test/Service1
-                          []
-                          (service1-fn
-                            "This is an example of an invalid docstring"
-                            [this] nil)))))))
+         Exception
+         #"Incorrect macro usage"
+         (macroexpand '(puppetlabs.trapperkeeper.services/service
+                         puppetlabs.trapperkeeper.services-test/Service1
+                         []
+                         (service1-fn
+                          "This is an example of an invalid docstring"
+                          [this] nil)))))))

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -51,6 +51,14 @@
 (defprotocol Service3
   (service3-fn [this]))
 
+(deftest test-services-not-required
+  (testing "services are not required to define lifecycle functions"
+    (let [service1 (service Service1
+                     []
+                     (service1-fn [this] "hi"))
+          app (bootstrap-services-with-empty-config [service1])]
+      (is (not (nil? app))))))
+
 (defn create-lifecycle-services
   [call-seq]
 
@@ -78,14 +86,6 @@
        (start [this context] (lc-fn context :start-service3))
        (stop [this context] (lc-fn context :stop-service3))
        (service3-fn [this] (lc-fn nil :service3-fn)))]))
-
-(deftest test-services-not-required
-  (testing "services are not required to define lifecycle functions"
-    (let [service1 (service Service1
-                     []
-                     (service1-fn [this] "hi"))
-          app (bootstrap-services-with-empty-config [service1])]
-      (is (not (nil? app))))))
 
 (deftest test-lifecycle-functions-ordered-correctly
   (testing "life cycle functions are called in the correct order"

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -194,9 +194,11 @@
         (ks-testutils/with-no-jvm-shutdown-hooks
          (let [app (internal/throw-app-error-if-exists!
                     (bootstrap-services-with-empty-config services))]
-           ; We can't use the with-app-with-empty-config macro because we don't want to use its implicit tk-app/stop call
-           ; We're asserting that the stop will happen because of the exception. So instead, we use the tk/run-app here to
-           ; block on the app until the restart is called an explodes in an exception.
+           ; We can't use the with-app-with-empty-config macro because we don't
+           ; want to use its implicit tk-app/stop call. We're asserting that
+           ; the stop will happen because of the exception. So instead, we use
+           ; the tk/run-app here to block on the app until the restart is
+           ; called an explodes in an exception.
            (let [app-running (future (tk/run-app app))]
              (is (= [:init-service1 :init-service2 :init-service3
                      :start-service1 :start-service2 :start-service3]

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -186,16 +186,17 @@
 (deftest test-exception-during-restart
   (testing "restart should halt if an exception is raised"
     (let [call-seq (atom [])
-          services (conj (create-lifecycle-services call-seq) (service
-                                                                EmptyService
-                                                                []
-                                                                (stop [this context] (throw (IllegalStateException. "Exploding Service")))))]
+          services (conj (create-lifecycle-services call-seq)
+                         (service
+                           EmptyService
+                           []
+                           (stop [this context] (throw (IllegalStateException. "Exploding Service")))))]
       (ks-testutils/with-no-jvm-shutdown-hooks
        ; We can't use the with-app-with-empty-config macro because we don't
        ; want to use its implicit tk-app/stop call. We're asserting that
        ; the stop will happen because of the exception. So instead, we use
        ; the tk/run-app here to block on the app until the restart is
-       ; called an explodes in an exception.
+       ; called and explodes in an exception.
        (let [app (internal/throw-app-error-if-exists!
                   (bootstrap-services-with-empty-config services))
              app-running (future (tk/run-app app))]
@@ -207,8 +208,7 @@
            @app-running
            (catch ExecutionException e
              (is (instance? IllegalStateException (.getCause e)))
-             (is (= "Exploding Service" (.. e getCause getMessage)))))
-         ))
+             (is (= "Exploding Service" (.. e getCause getMessage)))))))
       ; Here we validate that the stop completed but no new init happened
       (is (= [:init-service1 :init-service2 :init-service3
               :start-service1 :start-service2 :start-service3

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -167,6 +167,18 @@
               :stop-service3 :stop-service2 :stop-service1]
              @call-seq)))))
 
+(deftest test-context-cleared-on-restart
+  (testing "service contexts should be cleared out during a restart"
+    (let [test-context (atom {})
+          service1 (service EmptyService
+                     []
+                     (init [this context]
+                           (swap! test-context merge context)
+                           {:foo "bar"}))]
+      (with-app-with-empty-config app [service1]
+        (app/restart app))
+      (is (= {} @test-context)))))
+
 (deftest test-lifecycle-service-id-available
   (testing "service-id should be able to be called from any lifecycle phase"
     (let [test-context (atom {})

--- a/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
@@ -23,8 +23,8 @@
 (defn bootstrap-services-with-cli-data
   [services cli-data]
   (internal/throw-app-error-if-exists!
-    (tk/boot-services-with-config services
-                                  (config/parse-config-data cli-data))))
+    (tk/boot-services-with-config-fn services
+                                     #(config/parse-config-data cli-data))))
 
 (defmacro with-app-with-cli-data
   [app services cli-data & body]


### PR DESCRIPTION
This PR adds a restart function for TK apps that allows trapperkeeper to cleanly handle SIGHUP by calling restart on all of the registered apps. 