### PR TITLE
Optional Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 checkouts/
 pom.xml
+.nrepl-port

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [clj-time "0.5.1"]
                  [puppetlabs/kitchensink ~ks-version]
                  [prismatic/plumbing "0.4.2"]
-                 [prismatic/schema "0.4.0"]
+                 [prismatic/schema "1.0.4"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [org.clojure/tools.macro "0.1.2"]
                  [ch.qos.logback/logback-classic "1.1.1"]

--- a/src/puppetlabs/trapperkeeper/services.clj
+++ b/src/puppetlabs/trapperkeeper/services.clj
@@ -20,8 +20,10 @@
   "Common functions available to all services"
   (service-id [this] "An identifier for the service")
   (service-context [this] "Returns the context map for this service")
-  (get-service [this service-id] "Returns the service with the given service id")
+  (get-service [this service-id] "Returns the service with the given service id. Throws if service not present")
+  (maybe-get-service [this service-id] "Returns the service with the given service id. Returns nil if service not present")
   (get-services [this] "Returns a sequence containing all of the services in the app")
+  (service-included? [this service-id] "Returns true or false whether service is included")
   (service-symbol [this] "The namespaced symbol of the service definition, or `nil`
                           if no service symbol was provided."))
 
@@ -75,12 +77,16 @@
                                             (format
                                               "Call to 'get-service' failed; service '%s' does not exist."
                                               service-id#)))))
+                             (maybe-get-service [this# service-id#]
+                               (get-in ~'@tk-app-context [:services-by-id service-id#] nil))
                              (get-services [this#]
                                (-> ~'@tk-app-context
                                    :services-by-id
                                    (dissoc :ConfigService :ShutdownService)
                                    vals))
                              (service-symbol [this#] '~service-sym)
+                             (service-included? [this# service-id#]
+                               (not (nil? (get-in ~'@tk-app-context [:services-by-id service-id#] nil))))
 
                              Lifecycle
                              ~@(si/fn-defs fns-map lifecycle-fn-names)

--- a/src/puppetlabs/trapperkeeper/services_internal.clj
+++ b/src/puppetlabs/trapperkeeper/services_internal.clj
@@ -5,12 +5,11 @@
             [schema.core :as schema]
             [puppetlabs.kitchensink.core :as ks]))
 
-(def ServiceSymbol
-  "For internal use only; this schema gives us a way to differentiate between
-  a symbol representing the name of a service, and a symbol representing the
-  name of the *protocol* for a service.  This is necessary because the `service`
-  macro accepts both as optional leading arguments when defining a service."
-  {:service-symbol (schema/pred symbol?)})
+(def optional-dep-default
+  "This value is used in place of an optional service
+   when the service is not included. In the future, it may be a more interesting or
+   useful dummy service."
+  nil)
 
 (defn protocol?
   "A predicate to determine whether or not an object is a protocol definition"
@@ -29,23 +28,67 @@
        (symbol? (first sig))
        (vector? (second sig))))
 
-(defn fns-map?
-  "A predicate to determine whether or not an object is a map of fns, as
-  used internally by the `service` macro"
-  [m]
-  (and (map? m)
-       (every? keyword? (keys m))
-       (every? seq? (vals m))
-       (every? fn-sig? (apply concat (vals m)))))
+(def Protocol
+  "A schema to determine whether or not an object is a protocol definition."
+  (schema/pred protocol?))
 
-(defn var->symbol
+(def Symbol
+  "Interal schema type for validating symbol values."
+  (schema/pred symbol?))
+
+(def Var
+  "Interal schema type for validating var values."
+  (schema/pred var?))
+
+(def ServiceFnMap
+  "Internal schema for a service's map of function references."
+  {schema/Keyword IFn})
+
+(def FnsMap
+  "Internal schema for a map of a service's function body forms."
+  {schema/Keyword [(schema/pred fn-sig?)]})
+
+(def InternalServiceMap
+  "Schema defining TK's internal representation of a service. This is used while
+  processing the service macro."
+  {:service-sym (schema/maybe Symbol)
+   :service-protocol-sym (schema/maybe Symbol)
+   :service-id schema/Keyword
+   :service-fn-map ServiceFnMap
+   :dependencies (schema/pred sequential?)
+   :fns-map FnsMap})
+
+(def ServiceMap
+  "Schema defining the map used to represent a schema in the output service
+   map."
+  {schema/Keyword IFn})
+
+(def DependencyMap
+  "Schema for a map detailing optional vs. required dependencies for a
+   service."
+  {:optional (schema/pred vector?)
+   :required (schema/pred vector?)})
+
+(schema/defn ^:always-validate var->symbol :- Symbol
   "Returns a symbol for the var, including its namespace"
-  [fn-var]
-  {:pre [(var? fn-var)]
-   :post [(symbol? %)]}
+  [fn-var :- Var]
   (symbol (str (-> fn-var meta :ns .name))
           (str (-> fn-var meta :name))))
 
+(schema/defn ^:always-validate transform-deps-map :- (schema/pred vector?)
+  "Given a map of required and optional dependencies, return a vector that
+  adheres to Prismatic Graph's binding syntax. Specifically, optional
+  dependencies are transformed into {ServiceName nil}."
+  [deps :- DependencyMap]
+  (loop [optional (:optional deps) output (:required deps)]
+    (if (empty? optional)
+      output
+      (let [dep (first optional)
+            optional-form (array-map dep optional-dep-default)]
+        (recur (rest optional) (conj output optional-form))))))
+
+;; TODO Not converting to use schema since this fn's behavior should literally
+;; be a schema
 (defn validate-fn-forms!
   "Validate that all of the fn forms in the service body appear to be
   valid fn definitions.  Throws `IllegalArgumentException` otherwise."
@@ -60,6 +103,8 @@
                "Invalid service definition; expected function definitions following dependency list, invalid value: '%s'"
                (pr-str (first (filter #(not (seq? %)) fns))))))))
 
+;; TODO Not converting to use schema since this fn's behavior should literally
+;; be a schema
 (defn validate-deps-form!
   "Validate that the service body has a valid dependency specification.
   Throws `IllegalArgumentException` otherwise."
@@ -67,14 +112,18 @@
   {:pre [(seq? forms)]
    :post [(map? %)
           (= #{:fns :dependencies} (set (keys %)))]}
-  (let [f (first forms)]
-    (if (vector? f)
-      (merge {:dependencies f} (validate-fn-forms! (rest forms)))
-      (throw (IllegalArgumentException.
-               (format
-                 "Invalid service definition; expected dependency list following protocol, found: '%s'"
-                 (pr-str f)))))))
+  (let [f (first forms)
+        deps (cond
+               (vector? f) f
+               (map? f) (transform-deps-map f)
+               :else (throw (IllegalArgumentException.
+                             (format
+                              "Invalid service definition; expected dependency list following protocol, found: '%s'"
+                              (pr-str f)))))]
+    (merge {:dependencies deps} (validate-fn-forms! (rest forms)))))
 
+;; TODO Not converting to use schema since this fn's behavior should literally
+;; be a schema
 (defn find-prot-and-deps-forms!
   "Given the forms passed to the service macro, find the service protocol
   (if one is provided), the dependency list, and the function definitions.
@@ -96,34 +145,12 @@
                        "Invalid service definition; first form must be protocol or dependency list; found '%s'"
                        (pr-str f)))))))
 
-(defn parse-service-forms!*
-  "Given the forms passed to the service macro, find the service symbol (if one
-  is provided), the service protocol (if one is provided), the dependency list,
-  and the function definitions.  Throws `IllegalArgumentException` if the forms
-  do not represent a valid service.  Returns a vector containing the symbol,
-  protocol, dependency list, and fn forms."
-  [forms]
-  {:pre [(seq? forms)]
-   :post [(map? %)
-          (= #{:fns :dependencies :service-protocol-sym :service-sym}
-             (set (keys %)))
-          ((some-fn nil? symbol?) (:service-sym %))
-          ((some-fn nil? symbol?) (:service-protocol-sym %))
-          (vector? (:dependencies %))
-          (seq? (:fns %))]}
-  (let [f (first forms)]
-    (if (nil? (schema/check ServiceSymbol f))
-      (merge {:service-sym (get f :service-symbol)} (find-prot-and-deps-forms! (rest forms)))
-      (merge {:service-sym nil} (find-prot-and-deps-forms! forms)))))
-
-(defn validate-protocol-sym!
+(schema/defn ^:always-validate validate-protocol-sym! :- Protocol
   "Given a var, validate that the var exists and that its value is a protocol.
   Throws `IllegalArgumentException` if the var does not exist or if its value
   is something other than a protocol.  Returns the protocol."
-  [sym var]
-  {:pre [(symbol? sym)
-         ((some-fn nil? var?) var)]
-   :post [(protocol? %)]}
+  [sym :- Symbol
+   var :- (schema/maybe Var)]
   (if-not var
     (throw (IllegalArgumentException.
              (format "Unrecognized service protocol '%s'" sym))))
@@ -134,13 +161,12 @@
                        sym))))
     protocol))
 
-(defn validate-protocol-fn-names!
+(schema/defn ^:always-validate validate-protocol-fn-names! :- nil
   "Validate that the service protocol does not define any functions that have the
   same name as a lifecycle function.  Throws `IllegalArgumentException` if it does."
-  [service-protocol-sym service-fn-names lifecycle-fn-names]
-  {:pre [(symbol? service-protocol-sym)
-         (every? symbol? service-fn-names)
-         (every? symbol? lifecycle-fn-names)]}
+  [service-protocol-sym :- Symbol
+   service-fn-names :- [Symbol]
+   lifecycle-fn-names :- [Symbol]]
   (let [collisions (intersection (set (map name service-fn-names))
                                  (set (map name lifecycle-fn-names)))]
     (if-not (empty? collisions)
@@ -149,16 +175,13 @@
                        (name service-protocol-sym)
                        (first collisions)))))))
 
-(defn validate-provided-fns!
+(schema/defn ^:always-validate validate-provided-fns! :- nil
   "Validate that the seq of fns specified in a service body does not include
   any functions that are not part of the service protocol.  Throws `IllegalArgumentException`
   otherwise."
-  [service-protocol-sym service-fns provided-fns]
-  {:pre [((some-fn nil? symbol?) service-protocol-sym)
-         (set? service-fns)
-         (every? keyword? service-fns)
-         (set? provided-fns)
-         (every? keyword? provided-fns)]}
+  [service-protocol-sym :- (schema/maybe Symbol)
+   service-fns :- #{schema/Keyword}
+   provided-fns :- #{schema/Keyword}]
   (if (and (nil? service-protocol-sym)
            (> (count provided-fns) 0))
     (throw (IllegalArgumentException.
@@ -172,15 +195,13 @@
                  "Service attempts to define function '%s', which does not exist in protocol '%s'"
                  (name (first extras)) (name service-protocol-sym)))))))
 
-(defn validate-required-fns!
+(schema/defn ^:always-validate validate-required-fns! :- nil
   "Given a map of fn forms and a list of required function names,
   validate that all of the required functions are defined.  Throws
   `IllegalArgumentException` otherwise."
-  [protocol-sym required-fn-names fns-map]
-  {:pre [(fns-map? fns-map)
-         ((some-fn nil? coll?) required-fn-names)
-         (every? symbol? required-fn-names)
-         (symbol? protocol-sym)]}
+  [protocol-sym :- Symbol
+   required-fn-names :- (schema/maybe [Symbol])
+   fns-map :- FnsMap]
   (doseq [fn-name required-fn-names]
     (let [fn-name (ks/without-ns (keyword fn-name))]
       (if-not (contains? fns-map fn-name)
@@ -188,44 +209,34 @@
                  (format "Service does not define function '%s', which is required by protocol '%s'"
                          (name fn-name) (name protocol-sym))))))))
 
-(defn add-default-lifecycle-fn
+(schema/defn ^:always-validate add-default-lifecycle-fn :- FnsMap
   "Given a map of fns defined by a service, and the name of a lifecycle function,
   check to see if the fns map includes an implementation of the lifecycle function.
   If not, add a default implementation."
-  [fns-map fn-name]
-  {:pre [(fns-map? fns-map)
-         (symbol? fn-name)]
-   :post [(fns-map? %)
-          (= (ks/keyset %) (conj (ks/keyset fns-map) (keyword fn-name)))]}
+  [fns-map :- FnsMap
+   fn-name :- Symbol]
+  {:post [(= (ks/keyset %) (conj (ks/keyset fns-map) (keyword fn-name)))]}
   (if (contains? fns-map (keyword fn-name))
     fns-map
     (assoc fns-map (keyword fn-name)
       (list (cons fn-name '([this context] context))))))
 
-(defn add-default-lifecycle-fns
+(schema/defn ^:always-validate add-default-lifecycle-fns :- FnsMap
   "Given a map of fns comprising a service body, add in a default implementation
   for any lifecycle functions that are not overridden."
-  [lifecycle-fn-names fns-map]
-  {:pre [(coll? lifecycle-fn-names)
-         (every? symbol? lifecycle-fn-names)
-         (fns-map? fns-map)]
-   :post [(map? %)
-          (= (ks/keyset %)
+  [lifecycle-fn-names :- [Symbol]
+   fns-map :- FnsMap]
+  {:post [(= (ks/keyset %)
              (union (ks/keyset fns-map)
                     (set (map keyword lifecycle-fn-names))))]}
   (reduce add-default-lifecycle-fn fns-map lifecycle-fn-names))
 
-(defn fn-defs
+(schema/defn ^:always-validate fn-defs :- [(schema/pred seq?)]
   "Given a map of all of the function forms from a service definition, and a list
   of function names, return a sequence of all of the forms (including multi-arity forms)
   for the given function names."
-  [fns-map fn-names]
-  {:pre [(map? fns-map)
-         (every? keyword? (keys fns-map))
-         (every? seq? (vals fns-map))
-         (every? symbol? fn-names)]
-   :post [(seq? %)
-          (every? seq? %)]}
+  [fns-map :- FnsMap
+   fn-names :- [Symbol]]
   (reduce
     (fn [acc fn-name]
       (let [sigs (fns-map (ks/without-ns (keyword fn-name)))]
@@ -233,54 +244,39 @@
     '()
     fn-names))
 
-(defn build-service-map
+(schema/defn ^:always-validate build-service-map :- ServiceMap
   "Given a map from service protocol function names (keywords) to service
   protocol functions, and a service instance, build up a map of partial
   functions closing over the service instance"
-  [service-fn-map svc]
-  {:pre [(map? service-fn-map)
-         (every? keyword? (keys service-fn-map))
-         (every? ifn? (vals service-fn-map))]
-   :post [(map? %)
-          (every? keyword? (keys %))
-          (every? ifn? (vals %))]}
+  [service-fn-map :- ServiceFnMap
+   svc] ;; TODO this would be checked against Service, but it lives in services
   (into {}
         (map (fn [[fn-name fn-sym]]
                [fn-name (partial fn-sym svc)])
              service-fn-map)))
 
-(defn build-output-schema
+(schema/defn ^:always-validate build-output-schema :- {schema/Keyword (schema/pred (partial = IFn))}
   "Given a list of service protocol function names (keywords), build up the
   prismatic output schema for the service (a map from keywords to `IFn`)."
-  [service-fn-names]
-  {:pre [((some-fn nil? seq?) service-fn-names)
-         (every? keyword? service-fn-names)]
-   :post [(map? %)
-          (every? keyword? (keys %))
-          (every? #(= IFn %) (vals %))]}
+  [service-fn-names :- (schema/maybe [schema/Keyword])]
   (reduce (fn [acc fn-name] (assoc acc fn-name IFn))
           {}
           service-fn-names))
 
-(defn build-fns-map!
+(schema/defn ^:always-validate build-fns-map! :- FnsMap
   "Given the list of fn forms from the service body, build up a map of
   service fn forms.  The keys of the map will be keyword representations
   of the function names, and the values will be the fn forms.  The final
   map will include default implementations of any lifecycle functions that
   aren't overridden in the service body.  Throws `IllegalArgumentException`
   if the fn forms do not match the protocol."
-  [service-protocol-sym service-fn-names lifecycle-fn-names fns]
-  {:pre [((some-fn nil? symbol?) service-protocol-sym)
-         ((some-fn nil? coll?) service-fn-names)
-         (every? symbol? service-fn-names)
-         (coll? lifecycle-fn-names)
-         (every? symbol? lifecycle-fn-names)
-         (every? seq? fns)]
-   :post [(fns-map? %)
-          (= (ks/keyset %)
+  [service-protocol-sym :- (schema/maybe Symbol)
+   service-fn-names :- (schema/maybe (schema/pred coll?))
+   lifecycle-fn-names :- [Symbol]
+   fns :- [(schema/pred seq?)]]
+  {:post [(= (ks/keyset %)
              (union (set (map (comp ks/without-ns keyword) service-fn-names))
                     (set (map keyword lifecycle-fn-names))))]}
-
   (when service-protocol-sym
     (validate-protocol-fn-names! service-protocol-sym service-fn-names lifecycle-fn-names))
 
@@ -314,27 +310,21 @@
       (validate-required-fns! service-protocol-sym service-fn-names fns-map))
     fns-map))
 
-(defn get-service-id
+(schema/defn ^:always-validate get-service-id :- schema/Keyword
   "Generate service id based on service protocol symbol.  Returns the keyword of
   the symbol if the symbol is not nil; returns a keyword for a generated symbol
   otherwise."
-  [service-protocol-sym]
-  {:pre [((some-fn nil? symbol?) service-protocol-sym)]
-   :post [(keyword? %)]}
+  [service-protocol-sym :- (schema/maybe Symbol)]
   (ks/without-ns
     (if service-protocol-sym
       (keyword service-protocol-sym)
       (keyword (gensym "tk-service")))))
 
-(defn get-service-fn-map
+(schema/defn ^:always-validate get-service-fn-map :- ServiceFnMap
   "Get a map of service fns based on a protocol.  Keys will be keywords of the
   function names, values will be the protocol functions.  Returns
   an empty map if the protocol symbol is nil."
-  [service-protocol-sym]
-  {:pre [((some-fn nil? symbol?) service-protocol-sym)]
-   :post [(map? %)
-          (every? keyword? (keys %))
-          (every? symbol? (vals %))]}
+  [service-protocol-sym :- (schema/maybe Symbol)]
   (if service-protocol-sym
     (let [service-protocol-var  (resolve service-protocol-sym)
           service-protocol      (validate-protocol-sym!
@@ -346,23 +336,21 @@
               (mapv var->symbol (keys (:method-builders service-protocol)))))
     {}))
 
-(defn parse-service-forms!
+(schema/defn ^:always-validate parse-service-forms! :- InternalServiceMap
   "Parse the forms provided to the `service` macro.  Return a map
   containing all of the data necessary to implement the macro:
 
   :service-protocol-sym - the service protocol symbol (or nil if there is no protocol)
   :service-id           - a unique identifier (keyword) for the service
   :service-fn-map       - a map of symbols for the names of the functions provided by the protocol
-  :dependencies         - a vector specifying the dependencies of the service
+  :dependencies         - a vector (using fnk binding syntax) of deps or a map of :required and :optional deps.
   :fns-map              - a map of all of the fn definition forms in the service"
-  [lifecycle-fn-names forms]
-  {:pre [(every? symbol? lifecycle-fn-names)
-         (seq? forms)]
-   :post [(map? %)
-          (= #{:service-sym :service-protocol-sym :service-id :service-fn-map
-               :dependencies :fns-map} (ks/keyset %))]}
-  (let [{:keys [service-sym service-protocol-sym dependencies fns]}
-                          (parse-service-forms!* forms)
+  [lifecycle-fn-names :- [(schema/pred symbol?)]
+   forms :- (schema/pred seq?)]
+  (let [service-sym (:service-symbol (first forms))
+        service-sym (if (symbol? service-sym) service-sym nil)
+        forms (if (nil? service-sym) forms (rest forms))
+        {:keys [service-protocol-sym dependencies fns]} (find-prot-and-deps-forms! forms)
         service-id        (get-service-id service-protocol-sym)
         service-fn-map    (get-service-fn-map service-protocol-sym)
 
@@ -378,5 +366,3 @@
      :service-fn-map        service-fn-map
      :dependencies          dependencies
      :fns-map               fns-map}))
-
-

--- a/src/puppetlabs/trapperkeeper/services_internal.clj
+++ b/src/puppetlabs/trapperkeeper/services_internal.clj
@@ -57,7 +57,7 @@
     {:fns fns}
     (throw (IllegalArgumentException.
              (format
-               "Invalid service definition; expected function definitions following dependency list, invalid value: '\"hi\"'"
+               "Invalid service definition; expected function definitions following dependency list, invalid value: '%s'"
                (pr-str (first (filter #(not (seq? %)) fns))))))))
 
 (defn validate-deps-form!

--- a/test/puppetlabs/trapperkeeper/optional_deps_test.clj
+++ b/test/puppetlabs/trapperkeeper/optional_deps_test.clj
@@ -1,0 +1,132 @@
+(ns puppetlabs.trapperkeeper.optional-deps-test
+  (:require  [clojure.test :refer :all]
+             [puppetlabs.trapperkeeper.services :refer [service defservice get-service] :as tks]
+             [puppetlabs.trapperkeeper.app :as tka]
+             [puppetlabs.trapperkeeper.core :refer [build-app] :as tkc]
+             [schema.test :as schema-test]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(defprotocol HaikuService
+  (haiku [this topic]))
+
+(defprotocol SonnetService
+  (sonnet [this topic couplet]))
+
+(defprotocol PoetryService
+  (get-haiku [this])
+  (get-sonnet [this]))
+
+(defservice haiku-service
+  HaikuService
+  []
+  (haiku [this topic] ["here is a haiku"
+                       "about the topic you want"
+                       topic]))
+
+(defservice sonnet-service
+  SonnetService {:required []
+                 :optional []}
+  (sonnet [this topic couplet] (vec (concat ["imagine a sonnet"
+                                             (format "about %s" topic)]
+                                            couplet))))
+
+(deftest optional-deps-test
+  (testing "when dep form is well formed"
+    (testing "when there are no optional deps"
+      (let [poetry-service (service PoetryService
+                                  {:required [HaikuService SonnetService]
+                                   :optional []}
+                                  (get-haiku [this]
+                                             (let [haiku-svc (get-service this :HaikuService)]
+                                               (haiku haiku-svc "tea leaves thwart those who")))
+                                  (get-sonnet [this]
+                                              (let [sonnet-svc (get-service this :SonnetService)]
+                                                (sonnet sonnet-svc "designing futures" ["rhyming" "is overrated"]))))
+            app (build-app [haiku-service poetry-service sonnet-service] {})]
+        (is (= ["here is a haiku"
+                "about the topic you want"
+                "tea leaves thwart those who"]
+               (get-haiku (tka/get-service app :PoetryService))))
+        (is (= ["imagine a sonnet"
+                "about designing futures"
+                "rhyming"
+                "is overrated"]
+               (get-sonnet (tka/get-service app :PoetryService))))))
+
+    (testing "when there are normal optional deps"
+      (testing "and they are all included"
+        (let [poetry-service (service PoetryService
+                                    {:required []
+                                     :optional [HaikuService SonnetService]}
+                                    (get-haiku [this]
+                                               (let [haiku-svc (get-service this :HaikuService)]
+                                                 (haiku haiku-svc "tea leaves thwart those who")))
+                                    (get-sonnet [this]
+                                                (let [sonnet-svc (get-service this :SonnetService)]
+                                                  (sonnet sonnet-svc "designing futures" ["rhyming" "is overrated"]))))
+              app (build-app [haiku-service poetry-service sonnet-service] {})]
+          (is (= ["here is a haiku"
+                  "about the topic you want"
+                  "tea leaves thwart those who"]
+                 (get-haiku (tka/get-service app :PoetryService))))
+          (is (= ["imagine a sonnet"
+                  "about designing futures"
+                  "rhyming"
+                  "is overrated"]
+                 (get-sonnet (tka/get-service app :PoetryService))))))
+
+      (testing "and one is excluded"
+        (let [poetry-service (service PoetryService
+                                    {:required []
+                                     :optional [HaikuService SonnetService]}
+                                    (get-haiku [this]
+                                               (let [haiku-svc (get-service this :HaikuService)]
+                                                 (haiku haiku-svc "tea leaves thwart those who")))
+                                    (get-sonnet [this]
+                                                (if (tks/service-included? this :SonnetService)
+                                                  (sonnet (get-service this :SonnetService) "designing futures" ["rhyming" "is overrated"])
+                                                  ["imagine the saddest sonnet"])))
+              app (build-app [haiku-service poetry-service] {})]
+          (is (= ["here is a haiku"
+                  "about the topic you want"
+                  "tea leaves thwart those who"]
+                 (get-haiku (tka/get-service app :PoetryService))))
+          (is (= ["imagine the saddest sonnet"]
+                 (get-sonnet (tka/get-service app :PoetryService))))))
+
+      (testing "and all are excluded"
+        (let [poetry-service (service PoetryService
+                                    {:required []
+                                     :optional [HaikuService SonnetService]}
+                                    (get-haiku [this]
+                                               (if-let [haiku-svc (tks/maybe-get-service this :HaikuService)]
+                                                 (haiku haiku-svc ["tea leaves thwart those who"])
+                                                 ["imagine the saddest haiku"]))
+                                    (get-sonnet [this]
+                                                (if (tks/service-included? this :SonnetService)
+                                                  (sonnet (get-service this :SonnetService) "designing futures" ["rhyming" "is overrated"])
+                                                  ["imagine the saddest sonnet"])))
+              app (build-app [poetry-service] {})]
+          (is (= ["imagine the saddest haiku"]
+                 (get-haiku (tka/get-service app :PoetryService))))
+          (is (= ["imagine the saddest sonnet"]
+                 (get-sonnet (tka/get-service app :PoetryService)))))))
+
+    (testing "when there is a destructured required dep"
+      (let [poetry-service (service PoetryService
+                                    {:required [[:SonnetService sonnet]]
+                                     :optional [HaikuService]}
+                                    (get-haiku [this]
+                                               (if-let [haiku-svc (tks/maybe-get-service this :HaikuService)]
+                                                 (haiku haiku-svc ["tea leaves thwart those who"])
+                                                 ["imagine the saddest haiku"]))
+                                    (get-sonnet [this] (sonnet "designing futures" ["rhyming" "is overrated"])))
+            app (build-app [poetry-service sonnet-service] {})]
+        (is (= ["imagine the saddest haiku"]
+               (get-haiku (tka/get-service app :PoetryService))))
+        (is (= ["imagine a sonnet"
+                "about designing futures"
+                "rhyming"
+                "is overrated"]
+               (get-sonnet (tka/get-service app :PoetryService))))))))


### PR DESCRIPTION
This PR does the following:

* Upgrades the version of schema we use
* Uses schema to validate things in services-internal
* Adds support for optional dependencies; namely, transformation of an
  alternative dependency specification into a form Prismatic Graph can
  understand and adding a helper function for determining if a service
  has been included.

This commit is purely additive; no breaking changes are introduced.

This work represents the absolute minimum of work required to make this
a usable feature; while additive improvements may be made, the things
exposed here are not expected to change.

**Important notes**

* There are some functions marked with a TODO about turning them into schemas; I think the whole validation flow in `services-internal` can be drastically simplified into a single, schemafied function with schema exception catching that implement the various IllegalArgumentExceptions. I did not have time to incorporate that refactor and can ticket it.
* In doing this work, it became apparent that it would be excellent to be able to get a reference to the TrapperKeeper reified App from a service definition. That work was a stretch goal of this ticket and sadly I ran out of time. I can also ticket that.