### PR TITLE
(MAINT) increase timeout in service test

### DIFF
--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -154,7 +154,7 @@
         (beckon/raise! "HUP")
         (let [start (System/currentTimeMillis)]
           (while (and (not= (count @call-seq) 15)
-                     (< (- (System/currentTimeMillis) start) 1000))
+                     (< (- (System/currentTimeMillis) start) 5000))
             (Thread/yield)))
         (is (= (count @call-seq) 15))
         (is (= [:init-service1 :init-service2 :init-service3


### PR DESCRIPTION
The recent changes related to HUP support have a test that
sends a HUP signal and then waits for some period of time
to validate that the restart behavior took effect.  The initial
commit of this code appears to be using too low of a timeout
for some of our CI hardware.

This commit bumps the timeout up from 1s to 5s.