### PR TITLE
Revert "(TK-202) Increase logging to debug jenkins test failure"

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -5,9 +5,9 @@
         </encoder>
     </appender>
 
-    <logger name="puppetlabs" level="debug"/>
+    <logger name="puppetlabs" level="error"/>
 
-    <root level="debug">
+    <root level="error">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Reverts puppetlabs/trapperkeeper#207. Tests are passing now, so this is no longer required.