### PR TITLE
[discuss] Add service-apply function.

### DIFF
--- a/src/puppetlabs/trapperkeeper/services.clj
+++ b/src/puppetlabs/trapperkeeper/services.clj
@@ -35,6 +35,16 @@
 
 (def lifecycle-fn-names (map :name (vals (:sigs Lifecycle))))
 
+(defn service-apply
+  "Calls named function in other service, returning default if that service is not included."
+  [service fn-name default & args]
+  (if-let [service-fn (get service fn-name)]
+    (apply service-fn args)
+    (if (nil? service)
+      default
+      (throw (IllegalArgumentException.
+               (format "Call to 'service-apply' failed; service has no fn %s" fn-name))))))
+
 (defmacro service
   "Create a Trapperkeeper ServiceDefinition.
 

--- a/test/puppetlabs/trapperkeeper/optional_deps_test.clj
+++ b/test/puppetlabs/trapperkeeper/optional_deps_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.trapperkeeper.optional-deps-test
   (:require  [clojure.test :refer :all]
-             [puppetlabs.trapperkeeper.services :refer [service defservice get-service] :as tks]
+             [puppetlabs.trapperkeeper.services :refer [service defservice get-service service-apply] :as tks]
              [puppetlabs.trapperkeeper.app :as tka]
              [puppetlabs.trapperkeeper.core :refer [build-app] :as tkc]
              [schema.test :as schema-test]))
@@ -30,6 +30,44 @@
   (sonnet [this topic couplet] (vec (concat ["imagine a sonnet"
                                              (format "about %s" topic)]
                                             couplet))))
+
+(deftest service-apply-test
+  (let [poetry-service (service PoetryService
+                                {:required []
+                                 :optional [SonnetService HaikuService]}
+                                (get-haiku [this]
+                                           (service-apply HaikuService :bad-haiku
+                                                          "the worker puts her life into the object"
+                                                          "foo" "bar" "baz"))
+                                (get-sonnet [this]
+                                            (service-apply SonnetService :sonnet
+                                                           "sigh"
+                                                           "designing futures"
+                                                           ["rhyming" "is overrated"])))]
+    (testing "when using service-apply"
+      (testing "and service exists"
+        (let [app (build-app [haiku-service sonnet-service poetry-service] {})
+              poetry-svc (tka/get-service app :PoetryService)]
+          (testing "and fn exists"
+            (is (= ["imagine a sonnet"
+                    "about designing futures"
+                    "rhyming"
+                    "is overrated"]
+                   (get-sonnet poetry-svc))))
+          (testing "and fn does not exist"
+            (is (thrown-with-msg? IllegalArgumentException
+                                  #"has no fn :bad-haiku"
+                                  (get-haiku poetry-svc))))))
+      (testing "and service does not exist"
+        (let [app (build-app [poetry-service] {})
+              poetry-svc (tka/get-service app :PoetryService)]
+          (testing "and fn does not exist"
+            (testing "you get the default"
+              (is (= "the worker puts her life into the object"
+                     (get-haiku poetry-svc)))))
+          (testing "and fn exists"
+            (testing "you get the default"
+              (is (= "sigh" (get-sonnet poetry-svc))))))))))
 
 (deftest optional-deps-test
   (testing "when dep form is well formed"


### PR DESCRIPTION
This PR is a re-thought attempt at the `call-service-fn` I had originally added in TK-299.

I'm opening this because I came across a real usecase for this; when you want to have an optional dependency on a service without actually having to have a maven (ie, `project.clj`) dependency on that service's protocol.

This means you can be fully free from clojure namespace importation in your calling of TK functions of other services. This might be evil conceptually, but means optional dependencies can be even more of a burden-lifting feature in terms of project dependencies.