### PR TITLE
(TK-300) use clojure agent for lifecycle fns

### DIFF
--- a/src/puppetlabs/trapperkeeper/app.clj
+++ b/src/puppetlabs/trapperkeeper/app.clj
@@ -1,4 +1,18 @@
-(ns puppetlabs.trapperkeeper.app)
+(ns puppetlabs.trapperkeeper.app
+  (:require [schema.core :as schema]
+            [puppetlabs.trapperkeeper.services :as s]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schema
+
+(def TrapperkeeperAppContext
+  {:service-contexts {schema/Keyword {schema/Any schema/Any}}
+   :ordered-services [[(schema/one schema/Keyword "service-id")
+                       (schema/one (schema/protocol s/Service) "Service")]]
+   :services-by-id {schema/Keyword (schema/protocol s/Service)}})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; App Protocol
 
 (defprotocol TrapperkeeperApp
   "Functions available on a trapperkeeper application instance"

--- a/src/puppetlabs/trapperkeeper/app.clj
+++ b/src/puppetlabs/trapperkeeper/app.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.app
   (:require [schema.core :as schema]
-            [puppetlabs.trapperkeeper.services :as s]))
+            [puppetlabs.trapperkeeper.services :as s])
+  (:import (clojure.lang Agent IDeref)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schema
@@ -12,7 +13,9 @@
 (def TrapperkeeperAppContext
   {:service-contexts {schema/Keyword {schema/Any schema/Any}}
    :ordered-services TrapperkeeperAppOrderedServices
-   :services-by-id {schema/Keyword (schema/protocol s/Service)}})
+   :services-by-id {schema/Keyword (schema/protocol s/Service)}
+   :lifecycle-agent Agent
+   :shutdown-reason-promise IDeref})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; App Protocol

--- a/src/puppetlabs/trapperkeeper/app.clj
+++ b/src/puppetlabs/trapperkeeper/app.clj
@@ -5,10 +5,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schema
 
+(def TrapperkeeperAppOrderedServices
+  [[(schema/one schema/Keyword "service-id")
+    (schema/one (schema/protocol s/Service) "Service")]])
+
 (def TrapperkeeperAppContext
   {:service-contexts {schema/Keyword {schema/Any schema/Any}}
-   :ordered-services [[(schema/one schema/Keyword "service-id")
-                       (schema/one (schema/protocol s/Service) "Service")]]
+   :ordered-services TrapperkeeperAppOrderedServices
    :services-by-id {schema/Keyword (schema/protocol s/Service)}})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -1,10 +1,9 @@
 (ns puppetlabs.trapperkeeper.bootstrap
-  (:import (java.io Reader FileNotFoundException)
+  (:import (java.io FileNotFoundException)
            (java.net URI))
   (:require [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
-            [puppetlabs.trapperkeeper.plugins :as plugins]
             [puppetlabs.trapperkeeper.internal :as internal]
             [puppetlabs.trapperkeeper.services :as services]))
 

--- a/src/puppetlabs/trapperkeeper/services.clj
+++ b/src/puppetlabs/trapperkeeper/services.clj
@@ -70,7 +70,7 @@
             (let [svc# (reify
                          Service
                          (service-id [this#] ~service-id)
-                         (service-context [this#] (get ~'@tk-app-context ~service-id {}))
+                         (service-context [this#] (get-in ~'@tk-app-context [:service-contexts ~service-id] {}))
                          (get-service [this# service-id#]
                            (or (get-in ~'@tk-app-context [:services-by-id service-id#])
                                (throw (IllegalArgumentException.

--- a/src/puppetlabs/trapperkeeper/services.clj
+++ b/src/puppetlabs/trapperkeeper/services.clj
@@ -63,39 +63,39 @@
        ;; service map for prismatic graph
        (service-map [this]
          {~service-id
-           ;; the main service fnk for the app graph.  we add metadata to the fnk
-           ;; arguments list to specify an explicit output schema for the fnk
-           (fnk service-fnk# :- ~output-schema
-                ~(conj dependencies 'tk-app-context 'tk-service-refs)
-                (let [svc# (reify
-                             Service
-                             (service-id [this#] ~service-id)
-                             (service-context [this#] (get ~'@tk-app-context ~service-id {}))
-                             (get-service [this# service-id#]
-                               (or (get-in ~'@tk-app-context [:services-by-id service-id#])
-                                   (throw (IllegalArgumentException.
-                                            (format
-                                              "Call to 'get-service' failed; service '%s' does not exist."
-                                              service-id#)))))
-                             (maybe-get-service [this# service-id#]
-                               (get-in ~'@tk-app-context [:services-by-id service-id#] nil))
-                             (get-services [this#]
-                               (-> ~'@tk-app-context
-                                   :services-by-id
-                                   (dissoc :ConfigService :ShutdownService)
-                                   vals))
-                             (service-symbol [this#] '~service-sym)
-                             (service-included? [this# service-id#]
-                               (not (nil? (get-in ~'@tk-app-context [:services-by-id service-id#] nil))))
+          ;; the main service fnk for the app graph.  we add metadata to the fnk
+          ;; arguments list to specify an explicit output schema for the fnk
+          (fnk service-fnk# :- ~output-schema
+            ~(conj dependencies 'tk-app-context 'tk-service-refs)
+            (let [svc# (reify
+                         Service
+                         (service-id [this#] ~service-id)
+                         (service-context [this#] (get ~'@tk-app-context ~service-id {}))
+                         (get-service [this# service-id#]
+                           (or (get-in ~'@tk-app-context [:services-by-id service-id#])
+                               (throw (IllegalArgumentException.
+                                       (format
+                                        "Call to 'get-service' failed; service '%s' does not exist."
+                                        service-id#)))))
+                         (maybe-get-service [this# service-id#]
+                           (get-in ~'@tk-app-context [:services-by-id service-id#] nil))
+                         (get-services [this#]
+                           (-> ~'@tk-app-context
+                               :services-by-id
+                               (dissoc :ConfigService :ShutdownService)
+                               vals))
+                         (service-symbol [this#] '~service-sym)
+                         (service-included? [this# service-id#]
+                           (not (nil? (get-in ~'@tk-app-context [:services-by-id service-id#] nil))))
 
-                             Lifecycle
-                             ~@(si/fn-defs fns-map lifecycle-fn-names)
+                         Lifecycle
+                         ~@(si/fn-defs fns-map lifecycle-fn-names)
 
-                             ~@(if service-protocol-sym
-                                 `(~service-protocol-sym
-                                   ~@(si/fn-defs fns-map (vals service-fn-map)))))]
-                  (swap! ~'tk-service-refs assoc ~service-id svc#)
-                  (si/build-service-map ~service-fn-map svc#)))}))))
+                         ~@(if service-protocol-sym
+                             `(~service-protocol-sym
+                               ~@(si/fn-defs fns-map (vals service-fn-map)))))]
+              (swap! ~'tk-service-refs assoc ~service-id svc#)
+              (si/build-service-map ~service-fn-map svc#)))}))))
 
 (defmacro defservice
   [svc-name & forms]


### PR DESCRIPTION
This commit changes the handling of the TK lifecycle functions so that they are run on a Clojure agent.  This change is in place for both the "normal" (main, startup) code path of the life cycle functions as well as the HUP restarting.  This ensures that lifecycle functions will not be executed on the JVM signal handler thread, and that there will never be more than one thread attempting to execute lifecycle fns at a time.