### PR TITLE
(TK-319) Handle optional dependencies w/o protocol

### DIFF
--- a/src/puppetlabs/trapperkeeper/services_internal.clj
+++ b/src/puppetlabs/trapperkeeper/services_internal.clj
@@ -139,6 +139,7 @@
   (let [f (first forms)]
     (cond
       (symbol? f) (merge {:service-protocol-sym f} (validate-deps-form! (rest forms)))
+      (map? f) (merge {:service-protocol-sym nil} (validate-deps-form! forms))
       (vector? f) (merge {:service-protocol-sym nil} (validate-deps-form! forms))
       :else (throw (IllegalArgumentException.
                      (format

--- a/test/puppetlabs/trapperkeeper/optional_deps_test.clj
+++ b/test/puppetlabs/trapperkeeper/optional_deps_test.clj
@@ -32,6 +32,14 @@
                                             couplet))))
 
 (deftest optional-deps-test
+  (testing "when not using a protocol"
+    (let [poetry-service (service {:required [HaikuService]
+                                   :optional [SonnetService]}
+                                  (init [this ctx]
+                                        (assoc ctx
+                                               :haiku-svc (get-service this :HaikuService)
+                                               :sonnet-svc (tks/maybe-get-service this :SonnetService))))]
+      (is (build-app [poetry-service haiku-service] {}))))
   (testing "when dep form is well formed"
     (testing "when there are no optional deps"
       (let [poetry-service (service PoetryService


### PR DESCRIPTION
Fixes a bug where the `service` macro would fail if not using a service
protocol but using the new optional dependencies binding form.