### PR TITLE
(MAINT) add testutils bootstrap-services-with-config

### DIFF
--- a/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
@@ -10,11 +10,15 @@
 (def empty-config "./target/empty.ini")
 (fs/touch empty-config)
 
+(defn bootstrap-services-with-config
+  [services config]
+  (internal/throw-app-error-if-exists!
+   (tk/boot-services-with-config services config)))
+
 (defmacro with-app-with-config
   [app services config & body]
   `(ks-testutils/with-no-jvm-shutdown-hooks
-     (let [~app (internal/throw-app-error-if-exists!
-                  (tk/boot-services-with-config ~services ~config))]
+     (let [~app (bootstrap-services-with-config ~services ~config)]
        (try
          ~@body
          (finally


### PR DESCRIPTION
All of the various `with-app*` macros in the tk bootstrap testutils
have a corresponding `bootstrap-services*` fn that can be used in
cases where a test needs more control over the lifecycle of the app,
except for `with-app-with-config`.  This commit simply adds a
`bootstrap-services-with-config` to achieve parity there.