### PR TITLE
(FOR REVIEW) (TK-326) create max number of queued hup events

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -5,9 +5,9 @@
         </encoder>
     </appender>
 
-    <logger name="puppetlabs" level="error"/>
+    <logger name="puppetlabs" level="warn"/>
 
-    <root level="error">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/test/puppetlabs/trapperkeeper/internal_test.clj
+++ b/test/puppetlabs/trapperkeeper/internal_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tk-app]
-            [puppetlabs.trapperkeeper.internal :as internal]))
+            [puppetlabs.trapperkeeper.internal :as internal]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as logging]
+            [clojure.tools.logging :as log]))
 
 (deftest test-queued-restarts
   (testing "main lifecycle and calls to `restart-tk-apps` are not executed concurrently"
@@ -48,4 +51,62 @@
              @lifecycle-events))
       (tk-app/stop app)
       (is (= [:init :start :stop :init :start :stop :init :start :stop]
+             @lifecycle-events)))))
+
+(deftest test-max-queued-restarts
+  (let [stop-promise (promise)
+        lifecycle-events (atom [])
+        svc (tk/service
+             []
+             (init [this context]
+                   (swap! lifecycle-events conj :init)
+                   context)
+             (start [this context]
+                    (swap! lifecycle-events conj :start)
+                    context)
+             (stop [this context]
+                   @stop-promise
+                   (swap! lifecycle-events conj :stop)
+                   context))
+        app (testutils/bootstrap-services-with-config
+             [svc]
+             {})]
+
+    ;; the first restart will be picked up by the async worker, but it will
+    ;; block on the 'stop-promise', so no more work can be picked up off of the
+    ;; queue
+    (internal/restart-tk-apps [app])
+
+    ;; now we issue how ever many restarts we need to to fill up the queue
+    (dotimes [i internal/max-pending-lifecycle-events]
+      (internal/restart-tk-apps [app]))
+
+    ;; now we choose some arbitrary number of additional restarts to request,
+    ;; and confirm that we get a log message indicating that they were rejected
+    (dotimes [i 3]
+      (logging/with-test-logging
+       (internal/restart-tk-apps [app])
+
+       (is (logged? (format "Too many SIGHUP restart requests queued (%d); ignoring!"
+                            internal/max-pending-lifecycle-events)
+                    :warn)
+           "Missing expected log message when too many HUP requests queued")))
+
+    ;; now we unblock all of the queued restarts
+    (deliver stop-promise true)
+
+    ;; and validate that the life cycle events match up to that number of restarts
+    (let [expected-lifecycle-events (->> [:stop :init :start] ; each restart will add these
+                                         (repeat (+ 1 internal/max-pending-lifecycle-events))
+                                         (apply concat)
+                                         (concat [:init :start]) ; here is the initial init/start
+                                         vec)]
+      (while (< (count @lifecycle-events) (count expected-lifecycle-events))
+        (Thread/yield))
+      (is (= expected-lifecycle-events @lifecycle-events))
+
+      ;; now we stop the app
+      (tk-app/stop app)
+      ;; and make sure that we got one last :stop
+      (is (= (conj expected-lifecycle-events :stop)
              @lifecycle-events)))))

--- a/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/bootstrap.clj
@@ -10,11 +10,15 @@
 (def empty-config "./target/empty.ini")
 (fs/touch empty-config)
 
+(defn bootstrap-services-with-config
+  [services config]
+  (internal/throw-app-error-if-exists!
+   (tk/boot-services-with-config services config)))
+
 (defmacro with-app-with-config
   [app services config & body]
   `(ks-testutils/with-no-jvm-shutdown-hooks
-     (let [~app (internal/throw-app-error-if-exists!
-                  (tk/boot-services-with-config ~services ~config))]
+     (let [~app (bootstrap-services-with-config ~services ~config)]
        (try
          ~@body
          (finally


### PR DESCRIPTION
FOR REVIEW: this builds on PR #221, only the final commit of this PR is interesting.  Will rebase after that is merged.

-------------------------

This commit changes the HUP/restart logic so that if there are too
many events queued up in the core.async lifecycle channel, we won't
keep piling more on.  We instead just log a warning and ignore
the HUP request.