### PR TITLE
(TK-334) debug logging for restart and shutdown

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -181,4 +181,5 @@
          :cli-help (quit 0 (:message m) *out*)
          (throw+)))
      (finally
+       (log/debug "Finished TK main lifecycle, shutting down Clojure agent threads.")
        (shutdown-agents)))))

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -255,7 +255,7 @@
       (when-not (async/offer! lifecycle-channel
                               {:type :restart
                                :task-function restart-fn})
-        (log/warnf "Too many SIGHUP restart requests queued (%s); ignoring!"
+        (log/warnf "Ignoring new SIGHUP restart requests; too many requests queued (%s)"
                    max-pending-lifecycle-events)))))
 
 (defn register-sighup-handler

--- a/test/puppetlabs/trapperkeeper/internal_test.clj
+++ b/test/puppetlabs/trapperkeeper/internal_test.clj
@@ -86,7 +86,7 @@
       (logging/with-test-logging
        (internal/restart-tk-apps [app])
 
-       (is (logged? (format "Too many SIGHUP restart requests queued (%d); ignoring!"
+       (is (logged? (format "Ignoring new SIGHUP restart requests; too many requests queued (%s)"
                             internal/max-pending-lifecycle-events)
                     :warn)
            "Missing expected log message when too many HUP requests queued")))

--- a/test/puppetlabs/trapperkeeper/internal_test.clj
+++ b/test/puppetlabs/trapperkeeper/internal_test.clj
@@ -4,8 +4,7 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.internal :as internal]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
-            [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [clojure.tools.logging :as log]))
+            [puppetlabs.trapperkeeper.testutils.logging :as logging]))
 
 (deftest test-queued-restarts
   (testing "main lifecycle and calls to `restart-tk-apps` are not executed concurrently"


### PR DESCRIPTION
This commit adds/improves some debugging statements to clarify what
is happening with lifecycle events inside of TK, and when we shut
down the Clojure agent pool.
    
To achieve this we needed to provide a bit of schema around the
items that are put onto the core.async channel for lifecycle management.
