### PR TITLE
(TK-331) prioritize shutdowns

### DIFF
--- a/src/puppetlabs/trapperkeeper/app.clj
+++ b/src/puppetlabs/trapperkeeper/app.clj
@@ -19,6 +19,7 @@
    :ordered-services TrapperkeeperAppOrderedServices
    :services-by-id {schema/Keyword (schema/protocol s/Service)}
    :lifecycle-channel (schema/protocol async-prot/Channel)
+   :shutdown-channel (schema/protocol async-prot/Channel)
    :lifecycle-worker (schema/protocol async-prot/Channel)
    :shutdown-reason-promise IDeref})
 

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -18,7 +18,7 @@
 
 (def LifeCycleTask
   {:type (schema/enum :restart :shutdown :boot)
-   :task-function (schema/maybe IFn)})
+   :task-function IFn})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Private

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -236,18 +236,20 @@
               (log/debug "Received shutdown command, shutting down services")
               (async/close! shutdown-channel)
               (async/close! lifecycle-channel)
-              (task-function)
 
               (log/debug "Clearing lifecycle worker channels for shutdown.")
               ;; drain the channels to ensure that there are
               ;; no blocking puts, e.g. if a second shutdown request
               ;; was queued simultaneously
               (ks/while-let [msg (async/poll! shutdown-channel)]
-                (log/debug "Shutdown in progress, ignoring message on shutdown channel:"
-                           (:type msg)))
+                            (log/debug "Shutdown in progress, ignoring message on shutdown channel:"
+                                       (:type msg)))
               (ks/while-let [msg (async/poll! lifecycle-channel)]
-                (log/debug "Shutdown in progress, ignoring message on main lifecycle channel:"
-                           (:type msg)))
+                            (log/debug "Shutdown in progress, ignoring message on main lifecycle channel:"
+                                       (:type msg)))
+
+              (task-function)
+
               (log/debug "Service shutdown complete, exiting lifecycle worker loop")
               (catch Exception e
                 (log/debug e "Exception caught during shutdown!")))


### PR DESCRIPTION
This PR does the following:

* Tighten up the LifeCycleTask schema, since the `task-function` is no longer optional.
* Prioritize shutdowns over other events by adding a second core.async channel for requesting shutdowns, and using a prioritized `alts!` in the worker loop when reading off of the channel.
* Add logic to clean off any queued messages from the lifecycle channels during shutdown, so that we can ensure that no threads get stuck in a blocking `put` when we close the channels.