### PR TITLE
(TK-211) Disallow duplicate protocol implementations

### DIFF
--- a/dev-resources/bootstrapping/cli/bootstrap_with_comments.cfg
+++ b/dev-resources/bootstrapping/cli/bootstrap_with_comments.cfg
@@ -1,0 +1,5 @@
+# commented out line
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service # comment
+; another commented out line
+ ;puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service ; comment

--- a/dev-resources/bootstrapping/cli/duplicate_services.cfg
+++ b/dev-resources/bootstrapping/cli/duplicate_services.cfg
@@ -1,4 +1,0 @@
-# cli and foo implement the same service protocol
-puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
-puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
-puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service

--- a/dev-resources/bootstrapping/cli/duplicate_services.cfg
+++ b/dev-resources/bootstrapping/cli/duplicate_services.cfg
@@ -1,0 +1,4 @@
+# cli and foo implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service

--- a/dev-resources/bootstrapping/cli/duplicate_services/duplicates.cfg
+++ b/dev-resources/bootstrapping/cli/duplicate_services/duplicates.cfg
@@ -1,0 +1,6 @@
+# cli and foo implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
+# test-service-two and test-service-two-duplicate implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/test-service-two
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/test-service-two-duplicate

--- a/dev-resources/bootstrapping/cli/duplicate_services/split_one.cfg
+++ b/dev-resources/bootstrapping/cli/duplicate_services/split_one.cfg
@@ -1,0 +1,4 @@
+# cli and foo implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
+# test-service-two and test-service-two-duplicate implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/test-service-two-duplicate

--- a/dev-resources/bootstrapping/cli/duplicate_services/split_two.cfg
+++ b/dev-resources/bootstrapping/cli/duplicate_services/split_two.cfg
@@ -1,0 +1,4 @@
+# cli and foo implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
+# test-service-two and test-service-two-duplicate implement the same service protocol
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/test-service-two

--- a/dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg
+++ b/dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg
@@ -1,3 +1,3 @@
 puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
 puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service
-fake.notreal/wont-find-me
+non-existent-service/test-service

--- a/dev-resources/bootstrapping/cli/invalid_bootstrap.cfg
+++ b/dev-resources/bootstrapping/cli/invalid_bootstrap.cfg
@@ -1,0 +1,3 @@
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service
+fake.notreal/wont-find-me

--- a/dev-resources/bootstrapping/cli/invalid_entry_bootstrap.cfg
+++ b/dev-resources/bootstrapping/cli/invalid_entry_bootstrap.cfg
@@ -1,0 +1,2 @@
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service
+This is not a legit line.

--- a/dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg
+++ b/dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg
@@ -1,0 +1,1 @@
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/invalid-service-graph-service

--- a/dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg
+++ b/dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg
@@ -1,0 +1,3 @@
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service
+puppetlabs.trapperkeeper.examples.bootstrapping.test-services/non-existent-service

--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -218,7 +218,7 @@
   (for [{:keys [bootstrap-file line-number entry]} bootstrap-entries]
     (try+
       (let [{:keys [namespace service-name]} (parse-bootstrap-line! entry)]
-        (resolve-service! namespace service-name ))
+        (resolve-service! namespace service-name))
       ; Catch and re-throw as java exception
       (catch [:type ::bootstrap-parse-error] {:keys [message]}
         (throw (bootstrap-error entry bootstrap-file line-number message)))

--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -204,9 +204,9 @@
                                        (:line-number entry)
                                        (:entry entry))))]
     (IllegalArgumentException.
-      (format (str "Duplicate implementations found for service protocol '%s':\n%s")
-              protocol-id
-              (string/join "\n" (map make-error-message duplicate-services))))))
+     (format (str "Duplicate implementations found for service protocol '%s':\n%s")
+             protocol-id
+             (string/join "\n" (map make-error-message duplicate-services))))))
 
 (schema/defn check-duplicate-service-implementations!
   "Throws an exception if two services implement the same service protocol"
@@ -230,9 +230,9 @@
    line-number :- schema/Int
    original-message :- schema/Str]
   (IllegalArgumentException.
-    (format (str "Problem loading service '%s' on line '%s' in bootstrap "
-                 "configuration file '%s':\n%s")
-            entry line-number bootstrap-file original-message)))
+   (format (str "Problem loading service '%s' on line '%s' in bootstrap "
+                "configuration file '%s':\n%s")
+           entry line-number bootstrap-file original-message)))
 
 (schema/defn resolve-services! :- [(schema/protocol services/ServiceDefinition)]
   "Resolves each bootstrap entry into an instance of a trapperkeeper

--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -11,14 +11,24 @@
             [me.raynes.fs :as fs]
             [slingshot.slingshot :refer [try+ throw+]]))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Schemas
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (def ParsedBootstrapEntry {:namespace schema/Str :service-name schema/Str})
 (def AnnotatedBootstrapEntry {:entry schema/Str
                               :bootstrap-file schema/Str
                               :line-number schema/Int})
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (def bootstrap-config-file-name "bootstrap.cfg")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Private
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (schema/defn parse-bootstrap-line! :- ParsedBootstrapEntry
   "Parses an individual line from a trapperkeeper bootstrap configuration file.
@@ -254,6 +264,10 @@
                        into-ordered-list
                        {:set #{} :ordered-entries []}
                        entries))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (schema/defn parse-bootstrap-configs! :- [(schema/protocol services/ServiceDefinition)]
   [configs :- [schema/Str]]

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -3,6 +3,7 @@
   (:require [clojure.tools.logging :as log]
             [beckon]
             [plumbing.graph :as graph]
+            [slingshot.slingshot :refer [throw+]]
             [puppetlabs.kitchensink.core :refer [add-shutdown-hook! boolean? cli!]]
             [puppetlabs.trapperkeeper.config :refer [config-service]]
             [puppetlabs.trapperkeeper.app :as a]
@@ -11,7 +12,8 @@
             [puppetlabs.kitchensink.core :as ks]
             [schema.core :as schema]
             [clojure.core.async :as async]
-            [clojure.core.async.impl.protocols :as async-prot]))
+            [clojure.core.async.impl.protocols :as async-prot]
+            [clojure.string :as string]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Schemas
@@ -49,15 +51,16 @@
   [service-def]
   {:post [(satisfies? s/ServiceDefinition %)]}
   (if-not (satisfies? s/ServiceDefinition service-def)
-    (throw (IllegalArgumentException.
-            (str "Invalid service definition; expected a service "
-                 "definition (created via `service` or `defservice`); "
-                 "found: " (pr-str service-def)))))
+    (throw+ {:type :illegal-argument
+            :message (str "Invalid service definition; expected a service "
+                          "definition (created via `service` or `defservice`); "
+                          "found: " (pr-str service-def))}))
   (if (service-graph? (s/service-map service-def))
     service-def
-    (throw (IllegalArgumentException. (str "Invalid service graph; service graphs must "
-                                           "be nested maps of keywords to functions.  Found: "
-                                           (s/service-map service-def))))))
+    (throw+ {:type :illegal-argument
+             :message (str "Invalid service graph; service graphs must "
+                           "be nested maps of keywords to functions.  Found: "
+                           (s/service-map service-def))})))
 
 (defn parse-missing-required-key
   "Prismatic's graph compilation code throws `ExceptionInfo` objects if required

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -46,18 +46,18 @@
 
 (defn validate-service-graph!
   "Validates that a ServiceDefinition contains a valid trapperkeeper service graph.
-  Returns the service definition on success; throws an IllegalArgumentException
+  Returns the service definition on success; throws an ::invalid-service-graph
   if the graph is invalid."
   [service-def]
   {:post [(satisfies? s/ServiceDefinition %)]}
   (if-not (satisfies? s/ServiceDefinition service-def)
-    (throw+ {:type :illegal-argument
-            :message (str "Invalid service definition; expected a service "
-                          "definition (created via `service` or `defservice`); "
-                          "found: " (pr-str service-def))}))
+    (throw+ {:type ::invalid-service-graph
+             :message (str "Invalid service definition; expected a service "
+                           "definition (created via `service` or `defservice`); "
+                           "found: " (pr-str service-def))}))
   (if (service-graph? (s/service-map service-def))
     service-def
-    (throw+ {:type :illegal-argument
+    (throw+ {:type ::invalid-service-graph
              :message (str "Invalid service graph; service graphs must "
                            "be nested maps of keywords to functions.  Found: "
                            (s/service-map service-def))})))

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -258,7 +258,7 @@ puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service ;
   (testing "duplicate bootstrap entries are allowed"
     (let [bootstrap-path "./dev-resources/bootstrapping/cli/duplicate_entries.cfg"
           app (bootstrap-with-empty-config
-               ["--bootstrap-config" bootstrap-path])
+                ["--bootstrap-config" bootstrap-path])
           hello-world-svc (get-service app :HelloWorldService)]
       (is (= (hello-world hello-world-svc) "hello world")))))
 
@@ -282,8 +282,9 @@ puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service ;
       ;; (ie, this does not throw an exception)
       (bootstrap-with-empty-config ["--bootstrap-config" bootstrap-url]))))
 
-(deftest parse-bootstrap-config-throws
+(deftest parse-bootstrap-config-throws-good-error
   (testing "throws error with line number and file"
+    ; Load a bootstrap with a service that doesn't exist to generate an error
     (let [bootstrap (file "./dev-resources/bootstrapping/cli/invalid_bootstrap.cfg")]
       (is (thrown-with-msg?
             IllegalArgumentException

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -15,10 +15,11 @@
             [schema.test :as schema-test]
             [me.raynes.fs :as fs]))
 
-(use-fixtures :once
-  schema-test/validate-schemas
-  ;; Without this, "lein test NAMESPACE" and :only invocations may fail.
-  (fn [f] (reset-logging) (f)))
+(use-fixtures
+ :once
+ schema-test/validate-schemas
+ ;; Without this, "lein test NAMESPACE" and :only invocations may fail.
+ (fn [f] (reset-logging) (f)))
 
 (deftest bootstrapping
   (testing "Valid bootstrap configurations"
@@ -26,7 +27,7 @@
           app (parse-and-bootstrap bootstrap-config)]
 
       (testing "Can load a service based on a valid bootstrap config string"
-        (let [test-svc        (get-service app :TestService)
+        (let [test-svc (get-service app :TestService)
               hello-world-svc (get-service app :HelloWorldService)]
           (is (= (test-fn test-svc) :cli))
           (is (= (hello-world hello-world-svc) "hello world"))))
@@ -34,8 +35,8 @@
       (with-additional-classpath-entries ["./dev-resources/bootstrapping/classpath"]
         (testing "Looks for bootstrap config on classpath (dev-resources)"
           (with-test-logging
-            (let [app             (bootstrap-with-empty-config)
-                  test-svc        (get-service app :TestService)
+            (let [app (bootstrap-with-empty-config)
+                  test-svc (get-service app :TestService)
                   hello-world-svc (get-service app :HelloWorldService)]
               (is (logged?
                    #"Loading bootstrap config from classpath: 'file:/.*dev-resources/bootstrapping/classpath/bootstrap.cfg'"
@@ -50,8 +51,8 @@
                "user.dir"
                (.getAbsolutePath (file "./dev-resources/bootstrapping/cwd")))
               (with-test-logging
-                (let [app             (bootstrap-with-empty-config)
-                      test-svc        (get-service app :TestService)
+                (let [app (bootstrap-with-empty-config)
+                      test-svc (get-service app :TestService)
                       hello-world-svc (get-service app :HelloWorldService)]
                   (is (logged?
                        #"Loading bootstrap config from current working directory: '.*/dev-resources/bootstrapping/cwd/bootstrap.cfg'"
@@ -136,9 +137,9 @@
 
   (testing "comments allowed in bootstrap config file"
     (let [bootstrap-config "./dev-resources/bootstrapping/cli/bootstrap_with_comments.cfg"
-          service-maps      (->> bootstrap-config
-                                 parse-bootstrap-config!
-                                 (map service-map))]
+          service-maps (->> bootstrap-config
+                            parse-bootstrap-config!
+                            (map service-map))]
       (is (= (count service-maps) 2))
       (is (contains? (first service-maps) :HelloWorldService))
       (is (contains? (second service-maps) :TestService)))))
@@ -172,8 +173,8 @@
             test-svc-three (get-service app :TestServiceThree)
             hello-world-svc (get-service app :HelloWorldService)]
         (is (logged?
-              ; We can't know what order it will find the files on disk, so just
-              ; look for a partial match with the path we gave TK.
+             ; We can't know what order it will find the files on disk, so just
+             ; look for a partial match with the path we gave TK.
              (re-pattern (format "Loading bootstrap configs:\n%s"
                                  (fs/absolute bootstrap-path)))
              :debug))
@@ -239,7 +240,7 @@
   (testing "duplicate bootstrap entries are allowed"
     (let [bootstrap-path "./dev-resources/bootstrapping/cli/duplicate_entries.cfg"
           app (bootstrap-with-empty-config
-                ["--bootstrap-config" bootstrap-path])
+               ["--bootstrap-config" bootstrap-path])
           hello-world-svc (get-service app :HelloWorldService)]
       (is (= (hello-world hello-world-svc) "hello world")))))
 
@@ -247,17 +248,17 @@
   (testing "Duplicate service definitions causes error with filename and line numbers"
     (let [bootstrap "./dev-resources/bootstrapping/cli/duplicate_services.cfg"]
       (is (thrown-with-msg?
-            IllegalArgumentException
-            (re-pattern (str "Duplicate implementations found for service protocol ':TestService':\n"
-                             ".*/duplicate_services.cfg:2\n"
-                             "puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service\n"
-                             ".*/duplicate_services.cfg:3\n"
-                             "puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service"))
-            (parse-bootstrap-config! bootstrap))))))
+           IllegalArgumentException
+           (re-pattern (str "Duplicate implementations found for service protocol ':TestService':\n"
+                            ".*/duplicate_services.cfg:2\n"
+                            "puppetlabs.trapperkeeper.examples.bootstrapping.test-services/cli-test-service\n"
+                            ".*/duplicate_services.cfg:3\n"
+                            "puppetlabs.trapperkeeper.examples.bootstrapping.test-services/foo-test-service"))
+           (parse-bootstrap-config! bootstrap))))))
 
 (deftest config-file-in-jar
   (testing "Bootstrapping via a config file contained in a .jar"
-    (let [jar           (file "./dev-resources/bootstrapping/jar/this-jar-contains-a-bootstrap-config-file.jar")
+    (let [jar (file "./dev-resources/bootstrapping/jar/this-jar-contains-a-bootstrap-config-file.jar")
           bootstrap-url (str "jar:file:///" (.getAbsolutePath jar) "!/bootstrap.cfg")]
       ;; just test that this bootstrap config file can be read successfully
       ;; (ie, this does not throw an exception)
@@ -268,12 +269,12 @@
     ; Load a bootstrap with a service that doesn't exist to generate an error
     (let [bootstrap "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg"]
       (is (thrown-with-msg?
-            IllegalArgumentException
-            (re-pattern (str "Problem loading service 'non-existent-service/test-service' "
-                             "on line '3' in bootstrap configuration file "
-                             "'./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg'"
-                             ":\nUnable to load service: non-existent-service/test-service"))
-            (parse-bootstrap-config! bootstrap))))))
+           IllegalArgumentException
+           (re-pattern (str "Problem loading service 'non-existent-service/test-service' "
+                            "on line '3' in bootstrap configuration file "
+                            "'./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg'"
+                            ":\nUnable to load service: non-existent-service/test-service"))
+           (parse-bootstrap-config! bootstrap))))))
 
 (deftest get-annotated-bootstrap-entries-test
   (testing "file with comments"

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -368,7 +368,27 @@
   (testing "jar uri"
     (let [jar "./dev-resources/bootstrapping/jar/this-jar-contains-a-bootstrap-config-file.jar"
           config (str "jar:file:///" (.getAbsolutePath (file jar)) "!/bootstrap.cfg")]
-      ; The bootstrap in the jar contains an emtpy line at the end
+      ; The bootstrap in the jar contains an empty line at the end
       (is (= ["puppetlabs.trapperkeeper.examples.bootstrapping.test-services/hello-world-service"
               ""]
-             (read-config config))))))
+             (read-config config)))))
+  (testing "malformed uri is wrapped in our exception"
+    (let [config "\n"]
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"Specified bootstrap config file does not exist"
+           (read-config config)))))
+  (testing "Non-absolute uri is wrapped in our exception"
+    ; TODO This path is currently interpreted as a URI because TK checks
+    ; if it's a file, and if not, attemps to load as a URI
+    (let [config "./not-a-file"]
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"Specified bootstrap config file does not exist"
+           (println (read-config config))))))
+  (testing "Non-existent file in URI is wrapped in our exception"
+    (let [config "file:///not-a-file"]
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"Specified bootstrap config file does not exist"
+           (read-config config))))))

--- a/test/puppetlabs/trapperkeeper/examples/bootstrapping/test_services.clj
+++ b/test/puppetlabs/trapperkeeper/examples/bootstrapping/test_services.clj
@@ -46,6 +46,10 @@
   TestServiceTwo
   []
   (test-fn-two [this] :two))
+(defservice test-service-two-duplicate
+  TestServiceTwo
+  []
+  (test-fn-two [this] :two))
 
 (defservice test-service-three
   TestServiceThree


### PR DESCRIPTION
This PR extends TK to throw an error during startup if two bootstrap
entries implement the same service protocol. Previously TK would startup the
last entry it found that implemented a protocol and silently ignore the rest.

This PR also contains additions to the bootstrap namespace to give more
information when a bootstrap related error is raised. Since bootstrap entries
can now be split up between multiple files, the error messages give the
location of the bootstrap files and the line number where the offending
service entries were included.

This functionality is implemented by passing around a list of the bootstrap
entries annotated with the file and line number they came from.

This PR also makes some changes to maintain the ability to have duplicate
bootstrap entries, since TK might now see them as two services that implement
the same protocol, and error.