### PR TITLE
(TK-362) Honor log level in logged? macro

### DIFF
--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -327,8 +327,12 @@
    (let [match? (cond (ifn? msg-or-pred) msg-or-pred
                       (string? msg-or-pred) #(= msg-or-pred (:message %))
                       :else #(re-find msg-or-pred (:message %)))
-         one-element? #(and (seq %) (empty? (rest %)))]
-     (one-element? (filter match? (map event->map @*test-log-events*))))))
+         one-element? #(and (seq %) (empty? (rest %)))
+         correct-level? #(or (nil? maybe-level) (= maybe-level (:level %)))]
+     (->> (map event->map @*test-log-events*)
+          (filter correct-level?)
+          (filter match?)
+          (one-element?)))))
 
 (defmethod clojure.test/assert-expr 'logged? [is-msg form]
   "Asserts that exactly one event in *test-log-events* has a message

--- a/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
@@ -125,7 +125,14 @@
     (doseq [level @#'puppetlabs.trapperkeeper.testutils.logging/levels]
       (tgt/with-test-logging
         (log/log level "foo")
-        (is (logged? "foo" level))))))
+        (is (logged? "foo" level))))
+    ;; Does not match when logged above or below correct level
+    (tgt/with-test-logging
+      (log/debug "debug")
+      (is (not (tgt/logged? #"debug" :warn))))
+    (tgt/with-test-logging
+      (log/debug "debug")
+      (is (not (tgt/logged? #"debug" :trace))))))
 
 (deftest with-test-logging-debug
   (testing "basic matching"
@@ -144,7 +151,13 @@
     (doseq [level @#'puppetlabs.trapperkeeper.testutils.logging/levels]
       (tgt/with-test-logging-debug
         (log/log level "foo")
-        (is (logged? "foo" level)))))
+        (is (logged? "foo" level))))
+    (tgt/with-test-logging-debug
+      (log/debug "debug")
+      (is (not (tgt/logged? #"debug" :warn))))
+    (tgt/with-test-logging
+      (log/debug "debug")
+      (is (not (tgt/logged? #"debug" :trace)))))
   (testing "that events are logged to *err*"
     (tgt/with-test-logging-debug
       (let [err (with-out-str (binding [*err* *out*]


### PR DESCRIPTION
Previously we ignored the log-level parameter if it was supplied.

This adds test cases to ensure that logged? fails, as well as succeeds,
properly and updates the logged? matching mechanism to first filter logs
by log level if requested.