### PR TITLE
(TK-349) Log warning when service can't be found

### DIFF
--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -229,11 +229,11 @@
    line-number :- schema/Int
    original-message :- schema/Str]
   (IllegalArgumentException.
-   (format (str "%s:%s\nProblem loading service '%s':\n%s")
-           bootstrap-file line-number entry original-message)))
+   (format (str "Problem loading service '%s' from %s:%s:\n%s")
+           entry bootstrap-file line-number original-message)))
 
 (schema/defn resolve-and-handle-errors! :- (schema/maybe (schema/protocol services/ServiceDefinition))
-  "Attemps to resolve a bootstrap entry into a ServiceDefinition.
+  "Attempts to resolve a bootstrap entry into a ServiceDefinition.
   If the bootstrap entry can't be resolved, logs a warning and returns nil.
 
   Throws an IllegalArgumentException if there is a problem parsing the bootstrap
@@ -243,7 +243,7 @@
     (let [{:keys [namespace service-name]} (parse-bootstrap-line! entry)]
       (resolve-service! namespace service-name))
     (catch [:type ::missing-service] {:keys [message]}
-      (log/warnf "%s:%s\nUnable to load service '%s'" bootstrap-file line-number entry))
+      (log/warnf "Unable to load service '%s' from %s:%s" entry bootstrap-file line-number))
     ; Catch and re-throw as java exception
     (catch [:type ::internal/invalid-service-graph] {:keys [message]}
       (throw (bootstrap-error entry bootstrap-file line-number message)))

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -114,20 +114,6 @@
                #"Empty bootstrap config file"
                (parse-and-bootstrap bootstrap-config)))))
 
-      (testing "Service namespace doesn't exist"
-        (let [bootstrap-config "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg"]
-          (is (thrown-with-msg?
-               IllegalArgumentException
-               #"Problem loading service 'non-existent-service/test-service'"
-               (parse-and-bootstrap bootstrap-config)))))
-
-      (testing "Service definition doesn't exist"
-        (let [bootstrap-config "./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg"]
-          (is (thrown-with-msg?
-               IllegalArgumentException
-               #"Unable to load service: puppetlabs.trapperkeeper.examples.bootstrapping.test-services/non-existent-service"
-               (parse-and-bootstrap bootstrap-config)))))
-
       (testing "Invalid service graph"
         (let [bootstrap-config "./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg"]
           (is (thrown-with-msg?
@@ -285,16 +271,34 @@
       ;; (ie, this does not throw an exception)
       (bootstrap-with-empty-config ["--bootstrap-config" bootstrap-url]))))
 
-(deftest parse-bootstrap-config-throws-good-error
-  (testing "throws error with line number and file"
-    ; Load a bootstrap with a service that doesn't exist to generate an error
-    (let [bootstrap "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg"]
+(deftest parse-bootstrap-config-test
+  (testing "Missing service namespace logs warning"
+    (with-test-logging
+      (let [bootstrap-config "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg"]
+        (parse-bootstrap-config! bootstrap-config)
+        (is (logged?
+             (str "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg:3\n"
+                  "Unable to load service 'non-existent-service/test-service'")
+             :warn)))))
+
+  (testing "Missing service definition logs warning"
+    (with-test-logging
+      (let [bootstrap-config "./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg"]
+        (parse-bootstrap-config! bootstrap-config)
+        (is (logged?
+             (str "./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg:3\n"
+                  "Unable to load service "
+                  "'puppetlabs.trapperkeeper.examples.bootstrapping.test-services/non-existent-service'")
+             :warn)))))
+
+  (testing "errors are thrown with line number and file"
+    ; Load a bootstrap with a bad service graph to generate an error
+    (let [bootstrap "./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg"]
       (is (thrown-with-msg?
            IllegalArgumentException
-           (re-pattern (str "Problem loading service 'non-existent-service/test-service' "
-                            "on line '3' in bootstrap configuration file "
-                            "'./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg'"
-                            ":\nUnable to load service: non-existent-service/test-service"))
+           (re-pattern (str "./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg:1\n"
+                            "Problem loading service '.*invalid-service-graph-service':\n"
+                            "Invalid service definition"))
            (parse-bootstrap-config! bootstrap))))))
 
 (deftest get-annotated-bootstrap-entries-test

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -277,8 +277,8 @@
       (let [bootstrap-config "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg"]
         (parse-bootstrap-config! bootstrap-config)
         (is (logged?
-             (str "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg:3\n"
-                  "Unable to load service 'non-existent-service/test-service'")
+             (str "Unable to load service 'non-existent-service/test-service' from "
+                  "./dev-resources/bootstrapping/cli/fake_namespace_bootstrap.cfg:3")
              :warn)))))
 
   (testing "Missing service definition logs warning"
@@ -286,9 +286,9 @@
       (let [bootstrap-config "./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg"]
         (parse-bootstrap-config! bootstrap-config)
         (is (logged?
-             (str "./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg:3\n"
-                  "Unable to load service "
-                  "'puppetlabs.trapperkeeper.examples.bootstrapping.test-services/non-existent-service'")
+             (str "Unable to load service "
+                  "'puppetlabs.trapperkeeper.examples.bootstrapping.test-services/non-existent-service' "
+                  "from ./dev-resources/bootstrapping/cli/missing_definition_bootstrap.cfg:3")
              :warn)))))
 
   (testing "errors are thrown with line number and file"
@@ -296,8 +296,9 @@
     (let [bootstrap "./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg"]
       (is (thrown-with-msg?
            IllegalArgumentException
-           (re-pattern (str "./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg:1\n"
-                            "Problem loading service '.*invalid-service-graph-service':\n"
+           (re-pattern (str "Problem loading service "
+                            "'puppetlabs.trapperkeeper.examples.bootstrapping.test-services/invalid-service-graph-service' "
+                            "from ./dev-resources/bootstrapping/cli/invalid_service_graph_bootstrap.cfg:1:\n"
                             "Invalid service definition"))
            (parse-bootstrap-config! bootstrap))))))
 


### PR DESCRIPTION
This commit changes the behavior of TK when a bootstrap file contains a service
entry that can't be resolved. Previous TK would throw an error and fail to
start. Now TK will log a warning and attempt to continue loading the app

This is being added to support workflows where a user might want to add a
service entry to their bootstrap before a TK app actually requires it.

TK continues to throw errors and abort if the service entry is malformed or if
the service is found, but doesn't have a valid service graph