### PR TITLE
(TK-351) Improve empty bootstrap error message

### DIFF
--- a/dev-resources/bootstrapping/cli/split_bootstraps/empty/empty2.cfg
+++ b/dev-resources/bootstrapping/cli/split_bootstraps/empty/empty2.cfg
@@ -1,0 +1,3 @@
+# any entries here?
+
+# nope

--- a/src/puppetlabs/trapperkeeper/bootstrap.clj
+++ b/src/puppetlabs/trapperkeeper/bootstrap.clj
@@ -303,7 +303,8 @@
   ; where users are preparing to upgrade and might copy an entry to another file.
   (let [bootstrap-entries (remove-duplicate-entries (get-annotated-bootstrap-entries configs))]
     (when (empty? bootstrap-entries)
-      (throw (Exception. "Empty bootstrap config file")))
+      (throw (Exception. (str "No entries found in any supplied bootstrap file(s):\n"
+                              (string/join "\n" configs)))))
     (let [resolved-services (resolve-services! bootstrap-entries)]
       (check-duplicate-service-implementations! resolved-services bootstrap-entries)
       resolved-services)))


### PR DESCRIPTION
This commit makes the empty bootstrap error less ambiguous, and includes a list
of the bootstrap files that it searched in