### PR TITLE
(MAINT) Bump version for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.3.2
+
+This is a minor feature/bugfix release
+
+* [TK-347](https://tickets.puppetlabs.com/browse/TK-347) - Support directories
+  and paths in TK's "bootstrap-config" CLI argument
+* [TK-211](https://tickets.puppetlabs.com/browse/TK-211) - Trapperkeeper
+  doesn't error if two services implementing the same protocol are started
+* [TK-349](https://tickets.puppetlabs.com/browse/TK-349) - TK should not
+  fail during startup if an unrecognized service is found in bootstrap config
+* [TK351](https://tickets.puppetlabs.com/browse/TK-351) - Ensure all bootstrap
+  related errors log what file they come from
+
 ## 1.3.1
 
 This is a bugfix / maintenance / minor feature release

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def ks-version "1.3.0")
 (def logback-version "1.1.3")
 
-(defproject puppetlabs/trapperkeeper "1.3.2-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper "1.3.2"
   :description "A framework for configuring, composing, and running Clojure services."
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.


### PR DESCRIPTION
This is a minor feature/bugfix release

* TK-347 - Support directories and paths in TK's "bootstrap-config" CLI
  argument
* TK-211 - Trapperkeeper doesn't error if two services implementing the same
  protocol are started
* TK-349 - TK should not fail during startup if an unrecognized service is
  found in bootstrap config
* TK351 - Ensure all bootstrap related errors log what file they come from