### PR TITLE
(TK-345) add support for optional restart-file

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -1,11 +1,13 @@
 (ns puppetlabs.trapperkeeper.internal
-  (:import (clojure.lang ExceptionInfo IFn IDeref))
+  (:import (clojure.lang ExceptionInfo IFn IDeref)
+           (java.lang ArithmeticException NumberFormatException)
+           (java.io FileNotFoundException))
   (:require [clojure.tools.logging :as log]
             [beckon]
             [plumbing.graph :as graph]
             [slingshot.slingshot :refer [throw+]]
             [puppetlabs.kitchensink.core :refer [add-shutdown-hook! boolean? cli!]]
-            [puppetlabs.trapperkeeper.config :refer [config-service]]
+            [puppetlabs.trapperkeeper.config :refer [config-service get-in-config]]
             [puppetlabs.trapperkeeper.app :as a]
             [puppetlabs.trapperkeeper.common :as common]
             [puppetlabs.trapperkeeper.services :as s]
@@ -13,7 +15,8 @@
             [schema.core :as schema]
             [clojure.core.async :as async]
             [clojure.core.async.impl.protocols :as async-prot]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [me.raynes.fs :as fs]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Schemas
@@ -43,6 +46,24 @@
    (map? service-graph)
    (every? keyword? (keys service-graph))
    (every? (some-fn ifn? service-graph?) (vals service-graph))))
+
+(defn inc-restart-counter!
+  "Increments the counter in a restart-file for purposes of supporting HUP behavior"
+  [restart-file-path]
+  (try
+    (if (fs/exists? restart-file-path)
+      (if (and (fs/writeable? restart-file-path) (fs/readable? restart-file-path))
+        (spit restart-file-path (inc (Long/parseLong (slurp restart-file-path))))
+        (throw (IllegalStateException. (format "Restart file %s is not readable and/or writeable" restart-file-path))))
+      (let [dir-path (fs/parent restart-file-path)]
+        (fs/mkdirs dir-path)
+        (spit restart-file-path "1")))
+    (catch ArithmeticException e
+      (spit restart-file-path "1")
+      (log/debug "Number of restarts has exceeded Long/MAX_VALUE, resetting file to 1"))
+    (catch NumberFormatException e
+      (spit restart-file-path "1")
+      (log/error "Restart file is unparseable, resetting file to 1"))))
 
 (defn validate-service-graph!
   "Validates that a ServiceDefinition contains a valid trapperkeeper service graph.
@@ -562,6 +583,8 @@
         this)
       (a/start [this]
         (run-lifecycle-fns app-context s/start "start" ordered-services)
+        (when-let [restart-file (get-in-config (a/get-service this :ConfigService) [:global :restart-file])]
+          (inc-restart-counter! restart-file))
         this)
       (a/stop [this]
         (shutdown! app-context)
@@ -572,6 +595,8 @@
           (doseq [svc-id (keys services-by-id)] (swap! app-context assoc-in [:service-contexts svc-id] {}))
           (run-lifecycle-fns app-context s/init "init" ordered-services)
           (run-lifecycle-fns app-context s/start "start" ordered-services)
+          (when-let [restart-file (get-in-config (a/get-service this :ConfigService) [:global :restart-file])]
+            (inc-restart-counter! restart-file))
           this
           (catch Throwable t
             (deliver shutdown-reason-promise {:cause :service-error

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -71,8 +71,7 @@
                             (service1-fn [this] "hi"))
           temp-file (kitchensink/temp-file-name "counter")]
           (with-app-with-config app [service1] {:global {:restart-file temp-file}}
-            (app/restart app)
-            (is (= (slurp temp-file) "2"))))))
+            (is (= (slurp temp-file) "1"))))))
 
 (deftest test-restart-file-HUP-restart
   (testing "check that restart file correctly increments on HUP restarts"
@@ -97,7 +96,7 @@
         (is (= (slurp temp-file) "2"))))))
 
 (deftest test-invalid-restart-file
-  (testing "restart file should reset to 1 if the file is unparesable"
+  (testing "restart file should reset to 1 if the file is unparseable"
     (let [service1 (service Service1
                             []
                             (service1-fn [this] "hi"))
@@ -122,6 +121,7 @@
                             []
                             (service1-fn [this] "hi"))
           temp-file (fs/file (kitchensink/temp-dir "foo") "bar" "baz" "counter")]
+      (is (false? (fs/exists? temp-file)))
       (with-app-with-config app [service1] {:global {:restart-file temp-file}}
         (is (= (slurp temp-file) "1"))))))
 

--- a/test/puppetlabs/trapperkeeper/services_test.clj
+++ b/test/puppetlabs/trapperkeeper/services_test.clj
@@ -121,6 +121,7 @@
                             []
                             (service1-fn [this] "hi"))
           temp-file (fs/file (kitchensink/temp-dir "foo") "bar" "baz" "counter")]
+      (is (false? (fs/exists? (fs/parent temp-file))))
       (is (false? (fs/exists? temp-file)))
       (with-app-with-config app [service1] {:global {:restart-file temp-file}}
         (is (= (slurp temp-file) "1"))))))


### PR DESCRIPTION
This PR adds support for using a restart file that holds nothing but a long as a counter. This counter will increment each time a service completes its starting process. 