### PR TITLE
(TK-397) Update to latest version of logback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: clojure
 lein: lein2
-# Disabled due to buffer overflow issue below
-sudo: true
-#sudo: false
 jdk:
   - oraclejdk7
   - openjdk7
@@ -12,8 +9,7 @@ notifications:
   email: false
 
 # workaround for buffer overflow issue, ref https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ks-version "1.3.0")
-(def logback-version "1.1.3")
+(def logback-version "1.1.7")
 
 (defproject puppetlabs/trapperkeeper "1.4.2-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."


### PR DESCRIPTION
This update bumps us to the latest version of logback, which includes
(among other things) support for adding thread IDs to the HTTP
access log files.