### PR TITLE
(TK-405) Support specifying restart-file via a CLI arg

### DIFF
--- a/documentation/Command-Line-Arguments.md
+++ b/documentation/Command-Line-Arguments.md
@@ -8,11 +8,12 @@ Trapperkeeper's default mode of operation is to handle the processing of applica
 
 Note that if you absolutely need control over the command line argument processing, it is possible to circumvent the built-in handling by calling Trapperkeeper's `bootstrap` function directly; see additional details in the [Bootstrapping](Bootstrapping.md) page.
 
-Trapperkeeper supports three command-line arguments:
+Trapperkeeper supports four command-line arguments:
 
 * `--config/-c`: The path to the configuration file or directory. This option is used to initialize the configuration service. This argument is optional; if not specified, Trapperkeeper will act as if you had given it an empty configuration file.
 * `--bootstrap-config/-b`: This argument is optional; if specified, the value should be a path to a bootstrap configuration file, or a comma separated list of files and directories ([see below](#multiple-bootstrap-files)) that Trapperkeeper will use (instead of looking for `bootstrap.cfg` in the current working directory or on the classpath)
 * `--debug/-d`: This option is not required; it's a flag, so it will evaluate to a boolean.  If `true`, sets the logging level to DEBUG, and also sets the `:debug` key in the configuration map provided by the configuration-service.
+* `--restart-file/-r`: This argument is optional; if specified, the value should be a path to a file in which a start counter is incremented each time Trapperkeeper has started all of the services in an application.  See the [Restart File](Restart-File.md) page for additional details.
 
 ### Multiple bootstrap files
 The `--bootstrap-config` argument can be used to specify multiple bootstrap files. This way, a Trapperkeeper app's bootstrap configuration can be split up into multiple locations. You might want to do this to separate logically related services into their own files for instance.

--- a/documentation/Index.md
+++ b/documentation/Index.md
@@ -29,6 +29,7 @@ Trapperkeeper is a Clojure framework for hosting long-running applications and s
 * [Service Interfaces](Service-Interfaces.md)
 * [Command Line Arguments](Command-Line-Arguments.md)
  * [Other Ways to Boot](Command-Line-Arguments.md#other-ways-to-boot)
+* [Restart File Feature for Determining When Services Have Been Started](Restart-File.md)
 * [Test Utils](Test-Utils.md)
 * [Trapperkeeper Best Practices](Trapperkeeper-Best-Practices.md)
  * [To Trapperkeeper Or Not To Trapperkeeper](Trapperkeeper-Best-Practices.md#to-trapperkeeper-or-not-to-trapperkeeper)

--- a/documentation/Restart-File.md
+++ b/documentation/Restart-File.md
@@ -1,0 +1,64 @@
+# Experimental Feature: Restart File
+
+When using Trapperkeeper apps inside of packages, it is convenient for a service
+framework to have a clear indication as to when all of the Trapperkeeper
+services in the app have been started -- as opposed to just knowing when the
+Java process hosting the app has been spawned.  The "restart file" feature in
+Trapperkeeper provides this capability.  As a reference example, the
+[EZBake](https://github.com/puppetlabs/ezbake) build system for
+Trapperkeeper-based applications makes use of the "restart file" feature.  Its
+service packages can pause a hosting service framework (SysVinit, systemd)
+during a "service start" attempt until the app's services have all been started,
+or have failed to start.
+
+The "restart file" is considered to be a somewhat experimental feature in that
+the implementation may change in a future release.
+
+## Implementation Details
+
+Each time Trapperkeeper has successfully finished processing all of the start
+calls that it makes to each of the services in an application -- both at Java
+process start and after a service reload is requested -- it increments a
+counter in a file on disk.  The location of the file is controlled by the value
+of the `restart-file` setting.
+
+If the value in the file before services are started is '3', for example, the
+value will be updated to '4' after services have been started.  If the file does
+not exist at the time services have been started, the value is written as '1'.
+The value rolls back around to '1' if the value would be incremented beyond the
+maximum value for a `java.lang.Long` or if the contents of the file is otherwise
+unable to be parsed as an integer.
+
+In terms of using the restart file as an indication that services have been
+started -- for example, from a background script that accesses the file in a
+polling loop to determine when the start phase has finished -- it is best to
+just look for a change to the contents of the file rather than having any
+specific logic that interprets the integer values.  As noted earlier, the
+nature of the 'start' marker may change in a future release.
+
+## Configuration Details
+
+The `restart-file` setting can be specified either via a command line argument
+to Trapperkeeper...
+
+```
+-r | --restart-file /write/file/here
+```
+
+... or as a setting under the "global" section of a Trapperkeeper configuration
+file.  For example, a HOCON-formatted "global.conf" might have:
+
+```
+global: {
+  restart-file: /write/file/here
+}
+```
+
+In the event that the `restart-file` setting were specified both as a command
+line argument and within the "global" section of a Trapperkeeper configuration
+file, the value specified on the command line would be the one in which the
+'start' counter is incremented.
+
+If a value for the `restart-file` setting is not specified via either the
+command line or within the "global" section of a Trapperkeeper configuration
+file, Trapperkeeper will not write a 'start' counter to any file.

--- a/src/puppetlabs/trapperkeeper/common.clj
+++ b/src/puppetlabs/trapperkeeper/common.clj
@@ -9,4 +9,5 @@
               (schema/optional-key :bootstrap-config) schema/Str
               (schema/optional-key :config)           schema/Str
               (schema/optional-key :plugins)          schema/Str
+              (schema/optional-key :restart-file)     schema/Str
               (schema/optional-key :help)             schema/Bool})

--- a/src/puppetlabs/trapperkeeper/config.clj
+++ b/src/puppetlabs/trapperkeeper/config.clj
@@ -62,7 +62,14 @@
 (defn override-restart-file-from-cli-data
   [config-data cli-data]
   (if-let [cli-restart-file (:restart-file cli-data)]
-    (assoc-in config-data [:global :restart-file] cli-restart-file)
+    (do
+      (if (get-in config-data [:global :restart-file])
+        (log/warnf
+         (str
+          "restart-file setting specified both on command-line and "
+          "in config file, using command-line value: '%s'")
+         cli-restart-file))
+      (assoc-in config-data [:global :restart-file] cli-restart-file))
     config-data))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/puppetlabs/trapperkeeper/config.clj
+++ b/src/puppetlabs/trapperkeeper/config.clj
@@ -59,6 +59,12 @@
     #{".yaml" ".yml"}
     (yaml/parse-string (slurp file))))
 
+(defn override-restart-file-from-cli-data
+  [config-data cli-data]
+  (if-let [cli-restart-file (:restart-file cli-data)]
+    (assoc-in config-data [:global :restart-file] cli-restart-file)
+    config-data))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -122,7 +128,8 @@
       {:debug debug?}
       (-> (:config cli-data)
           (load-config)
-          (assoc :debug debug?)))))
+          (assoc :debug debug?)
+          (override-restart-file-from-cli-data cli-data)))))
 
 (defn initialize-logging!
   "Initializes the logging system based on the configuration data."

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -168,7 +168,8 @@
       --debug
       --bootstrap-config <bootstrap file>
       --config <.ini file or directory>
-      --plugins <plugins directory>"
+      --plugins <plugins directory>
+      --restart-file <restart file>"
   [cli-args :- [(schema/maybe schema/Str)]]
   (let [specs       [["-d" "--debug" "Turns on debug mode"]
                      ["-b" "--bootstrap-config BOOTSTRAP-CONFIG-FILE" "Path to bootstrap config file"]
@@ -176,7 +177,10 @@
                       (str "Path to a configuration file or directory of configuration files, "
                            "or a comma-separated list of such paths."
                            "See the documentation for a list of supported file types.")]
-                     ["-p" "--plugins PLUGINS-DIRECTORY" "Path to directory plugin .jars"]]
+                     ["-p" "--plugins PLUGINS-DIRECTORY" "Path to directory plugin .jars"]
+                     ["-r" "--restart-file RESTART-FILE"
+                      (str "Path to a file whose contents is incremented each time all of "
+                           "the configured services have been started.")]]
         required    []]
     (first (cli! cli-args specs required))))
 


### PR DESCRIPTION
This PR adds the ability for the restart-file setting to be
specified via a CLI arg.  The commit preserves the ability to source the
restart-file setting from the global section in Trapperkeeper
configuration.  In the event that the setting were specified in both
places, the setting used for the CLI arg would be the one used.

This PR also includes some documentation for the restart-file feature.