### PR TITLE
(SERVER-1494) introduce parent project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
   - oraclejdk7
   - openjdk7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.2
+
+This is a maintenance release.
+
+* [SERVER-1494](https://tickets.puppetlabs.com/browse/SERVER-1494) - use `lein-parent`
+  plugin to inherit dependency versions from parent project.
+
 ## 1.5.1
 
 This is a minor feature release

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ks-version "1.3.1")
+
 
 (defproject puppetlabs/trapperkeeper "1.5.2-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
@@ -37,9 +37,8 @@
                  [org.codehaus.janino/janino "2.7.8"]
                  [beckon "0.1.1"]
 
-                 [puppetlabs/typesafe-config "0.1.5"]
-                 [puppetlabs/kitchensink ~ks-version]
-
+                 [puppetlabs/typesafe-config]
+                 [puppetlabs/kitchensink]
                  ]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
@@ -64,7 +63,7 @@
              :dev {:source-paths ["examples/shutdown_app/src"
                                   "examples/java_service/src/clj"]
                    :java-source-paths ["examples/java_service/src/java"]
-                   :dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]]}
+                   :dependencies [[puppetlabs/kitchensink nil :classifier "test"]]}
 
              :testutils {:source-paths ^:replace ["test"]}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject puppetlabs/trapperkeeper "1.5.2-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
 
-  :min-lein-version "2.7.0"
+  :min-lein-version "2.7.1"
 
   :parent-project {:coords [puppetlabs/clj-parent "0.1.3"]
                    :inherit [:managed-dependencies]}

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,9 @@
-
-
 (defproject puppetlabs/trapperkeeper "1.5.2-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
 
   :min-lein-version "2.7.0"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.1.0-SNAPSHOT"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.1.3"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -57,8 +55,7 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
-  :profiles {:cljfmt {:plugins [[lein-cljfmt "0.5.0"]
-                                [lein-parent "0.2.1"]]
+  :profiles {:cljfmt {:plugins [[lein-cljfmt "0.5.0"]]
                       :parent-project {:path "ext/pl-clojure-style/project.clj"
                                        :inherit [:cljfmt]}}
              :dev {:source-paths ["examples/shutdown_app/src"
@@ -70,7 +67,7 @@
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :classifiers ^:replace []}}
 
-  :plugins [[lein-parent "0.3.0"]]
+  :plugins [[lein-parent "0.3.1"]]
 
   :main puppetlabs.trapperkeeper.main
   )

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,8 @@
                  ;; conflict with our version of logback-classic
                  [ch.qos.logback/logback-core]
                  [ch.qos.logback/logback-access]
+                 ;; Janino can be used for some advanced logback configurations
+                 [org.codehaus.janino/janino]
 
                  [clj-time]
                  [me.raynes/fs]
@@ -34,7 +36,6 @@
                  [prismatic/plumbing]
                  [prismatic/schema]
 
-                 [org.codehaus.janino/janino "2.7.8"]
                  [beckon "0.1.1"]
 
                  [puppetlabs/typesafe-config]

--- a/project.clj
+++ b/project.clj
@@ -30,9 +30,6 @@
                  [beckon "0.1.1"]
                  [org.clojure/core.async "0.2.374"]]
 
-  :lein-release {:scm         :git
-                 :deploy-via  :lein-deploy}
-
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
@@ -55,15 +52,13 @@
              :dev {:source-paths ["examples/shutdown_app/src"
                                   "examples/java_service/src/clj"]
                    :java-source-paths ["examples/java_service/src/java"]
-                   :dependencies [[spyscope "0.1.4"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]]
-                   :injections [(require 'spyscope.core)]}
+                   :dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]]}
 
              :testutils {:source-paths ^:replace ["test"]}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :classifiers ^:replace []}}
 
-  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
+  :plugins []
 
   :main puppetlabs.trapperkeeper.main
   )

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [prismatic/plumbing]
                  [prismatic/schema]
 
-                 [beckon "0.1.1"]
+                 [beckon]
 
                  [puppetlabs/typesafe-config]
                  [puppetlabs/kitchensink]

--- a/project.clj
+++ b/project.clj
@@ -1,34 +1,46 @@
-(def ks-version "1.3.0")
-(def logback-version "1.1.7")
+(def ks-version "1.3.1")
 
 (defproject puppetlabs/trapperkeeper "1.5.2-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
+
+  :min-lein-version "2.7.0"
+
+  :parent-project {:coords [puppetlabs/clj-parent "0.1.0-SNAPSHOT"]
+                   :inherit [:managed-dependencies]}
+
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/tools.logging "0.2.6"]
-                 [clj-time "0.5.1"]
-                 [puppetlabs/kitchensink ~ks-version]
-                 [prismatic/plumbing "0.4.2"]
-                 [prismatic/schema "1.0.4"]
-                 [org.clojure/tools.nrepl "0.2.3"]
-                 [org.clojure/tools.macro "0.1.2"]
-                 [ch.qos.logback/logback-classic ~logback-version]
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+                 [org.clojure/tools.nrepl]
+                 [org.clojure/tools.macro]
+                 [org.clojure/core.async]
+
+                 [org.slf4j/log4j-over-slf4j]
+                 [ch.qos.logback/logback-classic]
                  ;; even though we don't strictly have a dependency on the following two
                  ;; logback artifacts, specifying the dependency version here ensures
                  ;; that downstream projects don't pick up different versions that would
                  ;; conflict with our version of logback-classic
-                 [ch.qos.logback/logback-core ~logback-version]
-                 [ch.qos.logback/logback-access ~logback-version]
-                 [org.slf4j/log4j-over-slf4j "1.7.6"]
+                 [ch.qos.logback/logback-core]
+                 [ch.qos.logback/logback-access]
+
+                 [clj-time]
+                 [me.raynes/fs]
+                 [clj-yaml]
+
+                 [prismatic/plumbing]
+                 [prismatic/schema]
+
                  [org.codehaus.janino/janino "2.7.8"]
-                 [puppetlabs/typesafe-config "0.1.5"]
-                 [me.raynes/fs "1.4.6"]
-                 [clj-yaml "0.4.0"]
                  [beckon "0.1.1"]
-                 [org.clojure/core.async "0.2.374"]]
+
+                 [puppetlabs/typesafe-config "0.1.5"]
+                 [puppetlabs/kitchensink ~ks-version]
+
+                 ]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
@@ -58,7 +70,7 @@
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :classifiers ^:replace []}}
 
-  :plugins []
+  :plugins [[lein-parent "0.3.0"]]
 
   :main puppetlabs.trapperkeeper.main
   )


### PR DESCRIPTION
These commits clean up some cruft from the project.clj, and introduce the `lein-parent` plugin to allow us to inherit dependency versions from the parent project.  Also updates the CHANGELOG for a 1.5.2 release.