### PR TITLE
(maint) Update trapperkeeper to clj-parent latest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.1.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/test/puppetlabs/trapperkeeper/bootstrap_test.clj
+++ b/test/puppetlabs/trapperkeeper/bootstrap_test.clj
@@ -91,13 +91,13 @@
           (try+
             (bootstrap-with-empty-config ["--bootstrap-config" nil])
             (catch map? m
-              (is (contains? m :type))
-              (is (= :cli-error (without-ns (:type m))))
-              (is (= :puppetlabs.kitchensink.core/cli-error (:type m)))
-              (is (contains? m :message))
+              (is (contains? m :kind))
+              (is (= :cli-error (without-ns (:kind m))))
+              (is (= :puppetlabs.kitchensink.core/cli-error (:kind m)))
+              (is (contains? m :msg))
               (is (re-find
                    #"Missing required argument for.*--bootstrap-config"
-                   (m :message)))
+                   (m :msg)))
               (reset! got-expected-exception true)))
           (is (true? @got-expected-exception))))
 

--- a/test/puppetlabs/trapperkeeper/core_test.clj
+++ b/test/puppetlabs/trapperkeeper/core_test.clj
@@ -72,13 +72,13 @@
       (try+
         (parse-cli-args! ["--invalid-argument"])
         (catch map? m
-          (is (contains? m :type))
-          (is (= :cli-error (without-ns (:type m))))
-          (is (= :puppetlabs.kitchensink.core/cli-error (:type m)))
-          (is (contains? m :message))
+          (is (contains? m :kind))
+          (is (= :cli-error (without-ns (:kind m))))
+          (is (= :puppetlabs.kitchensink.core/cli-error (:kind m)))
+          (is (contains? m :msg))
           (is (re-find
                #"Unknown option.*--invalid-argument"
-               (m :message)))
+               (m :msg)))
           (reset! got-expected-exception true)))
       (is (true? @got-expected-exception))))
 


### PR DESCRIPTION
This updates trapperkeeper to use the latest clj-parent, which brings in
some breaking changes from clj-kitchensink. These only affect the
exception thrown by `internal/parse-cli-args!`.