### PR TITLE
(TK-430) Bump clj-parent to 0.3.3 and i18n to 0.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -69,7 +69,7 @@
                        :classifiers ^:replace []}}
 
   :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.4.3"]]
+            [puppetlabs/i18n "0.6.0"]]
 
   :main puppetlabs.trapperkeeper.main
   )


### PR DESCRIPTION
This commit bumps the clj-parent dependency to 0.3.3 and i18n plugin
dependency to 0.6.0.