### PR TITLE
(TK-439) Handle exceptions having no type in main

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -173,10 +173,12 @@
           (internal/parse-cli-args!)
           (run))
       (catch map? m
-        (case (without-ns (:type m))
-          :cli-error (quit 1 (:message m) *err*)
-          :cli-help (quit 0 (:message m) *out*)
-          (throw+)))
+        (let [type (:type m)]
+          (if (keyword? type)
+            (case (without-ns (:type m))
+              :cli-error (quit 1 (:message m) *err*)
+              :cli-help (quit 0 (:message m) *out*))))
+        (throw+))
       (finally
         (log/debug (i18n/trs "Finished TK main lifecycle, shutting down Clojure agent threads."))
         (shutdown-agents)))))


### PR DESCRIPTION
Previously, if an unhandled exception that can be coerced into a map but
that does not have a `:type` key in it were propagated up to
Trapperkeeper's main function, the exception output would be mishandled.
This commit rethrows the original exception if a nil value is found for the
`:type` key in the map, allowing the original exception output to be
displayed properly.