### PR TITLE
(maint) Add log message for finishing lifecycle function

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -231,7 +231,10 @@
                          lifecycle-fn
                          lifecycle-fn-name
                          service-id
-                         s))
+                         s)
+      (log/debug (i18n/trs "Finished running lifecycle function ''{0}'' for service ''{1}''"
+                           lifecycle-fn-name
+                           service-id)))
     (catch Throwable t
       (log/error t (i18n/trs "Error during service {0}!!!" lifecycle-fn-name))
       (throw t))))


### PR DESCRIPTION
Previously trapperkeeper would log a message when beginning to run a
lifecycle function, but not when the lifecycle function had returned.
This means that when debugging failures it can be challenging to tell
if a service has died mid-lifecycle function (depending on how much
logging that service has implemented). To alleviate that somewhat, this
commit adds a log message at debug level for when the lifecycle function
has finished.