### PR TITLE
(maint) Add plugin jars to clojure's base loader

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def ks-version "2.5.2")
+
 (defproject puppetlabs/trapperkeeper "1.5.4-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
 
@@ -40,7 +42,7 @@
                  [beckon]
 
                  [puppetlabs/typesafe-config]
-                 [puppetlabs/kitchensink]
+                 [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n]
                  ]
 
@@ -65,7 +67,7 @@
              :dev {:source-paths ["examples/shutdown_app/src"
                                   "examples/java_service/src/clj"]
                    :java-source-paths ["examples/java_service/src/java"]
-                   :dependencies [[puppetlabs/kitchensink nil :classifier "test"]]}
+                   :dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]]}
 
              :testutils {:source-paths ^:replace ["test"]}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]

--- a/src/puppetlabs/trapperkeeper/plugins.clj
+++ b/src/puppetlabs/trapperkeeper/plugins.clj
@@ -98,7 +98,8 @@
         (do
           (verify-no-duplicate-resources plugins)
           (doseq [jar (jars-in-dir plugins)]
-            (log/info (i18n/trs "Adding plugin .jar to classpath." (.getAbsolutePath jar)))
-            (kitchensink/add-classpath jar)))
+            (log/warn (i18n/trs "Adding plugin {0} to classpath." (.getAbsolutePath jar)))
+            (kitchensink/add-classpath jar)
+            (kitchensink/add-classpath jar (clojure.lang.RT/baseLoader))))
         (throw (IllegalArgumentException.
                  (i18n/trs "Plugins directory {0} does not exist" plugins-path)))))))

--- a/test/puppetlabs/trapperkeeper/plugins_test.clj
+++ b/test/puppetlabs/trapperkeeper/plugins_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.trapperkeeper.plugins-test
   (:require [clojure.test :refer :all]
-            [clojure.java.io :refer [file]]
+            [clojure.java.io :refer [file resource]]
             [puppetlabs.trapperkeeper.plugins :refer :all]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.app :refer [get-service service-graph]]
@@ -42,4 +42,6 @@
           service-fn (-> (service-graph app)
                          :PluginTestService
                          :moo)]
-      (is (= "This message comes from the plugin test service." (service-fn))))))
+      (is (= "This message comes from the plugin test service." (service-fn)))
+      ;; Can it also load resources from that jar
+      (is (resource "test_services/plugin_test_services.clj")))))


### PR DESCRIPTION
In Java 9 to add a jar to the classpath, we have to add a new
classloader in the hierarchy on the Thread (this is where io/resource
will look) and also to the clojure baseLoader (this is where clojure
will look for actual code). In Java 8 since the base hierarchy was
modifiable we could just change one place and it would be seen
everywhere.

I've also made the kitchensink dependency explicit, since it really does depend on this version number.