### PR TITLE
(TK-466) Log SIGHUP events at INFO level

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -302,7 +302,7 @@
 (defn restart-tk-apps
   "Call restart on all tk apps."
   [apps]
-  (log/debug (i18n/trs "SIGHUP handler restarting TK apps."))
+  (log/info (i18n/trs "SIGHUP handler restarting TK apps."))
   (doseq [app apps]
     (let [{:keys [lifecycle-channel]} @(a/app-context app)
           restart-fn #(a/restart app)]


### PR DESCRIPTION
This commit boosts the message logged by the SIGHUP handler from DEBUG to INFO.
This change makes it easy to see from logs when a SIGHUP came into the service.