### PR TITLE
(TK-471) Capture formatted messages in testutils.logging

### DIFF
--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -39,7 +39,7 @@
   messages to \"\"."
   {:logger (.getLoggerName event)
    :level  (level-keywords (.getLevel event))
-   :message (.getMessage event)
+   :message (.getFormattedMessage event)
    :exception (.getThrowableProxy event)})
 
 ;; Perhaps make call-with-started and with-started public in
@@ -448,7 +448,7 @@
                             entry [(.getLoggerName logging-event)
                                    (.getLevel logging-event)
                                    ex
-                                   (str (.getMessage logging-event))]]
+                                   (str (.getFormattedMessage logging-event))]]
                         (when debug? (log-to-console entry))
                         (swap! destination conj entry)))
                     (close []))]

--- a/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
@@ -4,7 +4,9 @@
    [clojure.tools.logging :as log]
    [puppetlabs.kitchensink.core :as kitchensink]
    [puppetlabs.trapperkeeper.logging :refer [reset-logging root-logger-name]]
-   [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]]))
+   [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]])
+  (import
+    (org.slf4j LoggerFactory)))
 
 ;; Without this, "lein test NAMESPACE" and :only invocations may fail.
 (use-fixtures :once (fn [f] (reset-logging) (f)))
@@ -132,7 +134,12 @@
       (is (not (tgt/logged? #"debug" :warn))))
     (tgt/with-test-logging
       (log/debug "debug")
-      (is (not (tgt/logged? #"debug" :trace))))))
+      (is (not (tgt/logged? #"debug" :trace)))))
+  (testing "captures parameterized slf4j messages"
+    (tgt/with-test-logging
+      (let [test-logger (LoggerFactory/getLogger "tk-test")]
+      (.info test-logger "Log message: {}" "odelay")
+      (is (tgt/logged? #"odelay"))))))
 
 (deftest with-test-logging-debug
   (testing "basic matching"


### PR DESCRIPTION
This commit updates testutils.logging such that the logged? assertion will
correctly match formatted log messages, such as those produced by SLF4J.
Prior to this commit, the matching machinery called .getMessage to recover
the logged message from LoggingEvent instances. The .getFormattedMessage
method is now called, which resolves format strings that may have been used.