### PR TITLE
(orch-2282) Updates trapperkeeper to use the latest nrepl/nrepl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: clojure
 jdk:
   - oraclejdk9
   - oraclejdk8
-  - openjdk7
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.0.0
+
+This is a maintenance release
+
+* [ORCH-2282](https://tickets.puppetlabs.com/browse/ORCH-2282) - Updates to current clj-parent
+to support using nrepl/nrepl
+* Updates required for using nrepl/nrepl; mainline development for nrepl moved from
+org.clojure/tools.nrepl as of the 0.3.x series (last on this line was 0.2.13)
+* Updating to this version of trapperkeeper requires lein >=2.9.0 (:min-lein-version updated)
+* Drops support for JDK7
+
 ## 1.5.6
 
 This is a maintenance release

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
 (def ks-version "2.5.2")
 
-(defproject puppetlabs/trapperkeeper "1.5.7-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper "2.0.0-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
 
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :min-lein-version "2.7.1"
+  :min-lein-version "2.9.0"
 
-  :parent-project {:coords [puppetlabs/clj-parent "0.4.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "1.7.24"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -17,7 +17,6 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]
-                 [org.clojure/tools.nrepl]
                  [org.clojure/tools.macro]
                  [org.clojure/core.async]
 
@@ -34,7 +33,7 @@
 
                  [clj-time]
                  [me.raynes/fs]
-                 [clj-yaml]
+                 [circleci/clj-yaml]
 
                  [prismatic/plumbing]
                  [prismatic/schema]
@@ -44,6 +43,7 @@
                  [puppetlabs/typesafe-config]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n]
+                 [nrepl/nrepl]
                  ]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/src/puppetlabs/trapperkeeper/services/nrepl/nrepl_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/nrepl/nrepl_service.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.nrepl.nrepl-service
   (:require
     [clojure.tools.logging :as log]
-    [clojure.tools.nrepl.server :as nrepl]
+    [nrepl.server :as nrepl]
     [puppetlabs.kitchensink.core :refer [to-bool]]
     [puppetlabs.trapperkeeper.core :refer [defservice]]
     [puppetlabs.i18n.core :as i18n]))

--- a/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.trapperkeeper.services.nrepl.nrepl-service-test
   (:require [clojure.test :refer :all]
-            [clojure.tools.nrepl :as repl]
+            [nrepl.core :as repl]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
             [puppetlabs.trapperkeeper.services.nrepl.nrepl-service :refer :all]
             [schema.test :as schema-test]))

--- a/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_test_send_middleware.clj
+++ b/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_test_send_middleware.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.nrepl.nrepl-test-send-middleware
-  (:require [clojure.tools.nrepl.transport :as t]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]])
-  (:use [clojure.tools.nrepl.misc :only [response-for]]))
+  (:require [nrepl.transport :as t]
+            [nrepl.middleware :refer [set-descriptor!]])
+  (:use [nrepl.misc :only [response-for]]))
 
 (defn send-test
   [h]

--- a/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging_test.clj
@@ -5,7 +5,7 @@
    [puppetlabs.kitchensink.core :as kitchensink]
    [puppetlabs.trapperkeeper.logging :refer [reset-logging root-logger-name]]
    [puppetlabs.trapperkeeper.testutils.logging :as tgt :refer [event->map]])
-  (import
+  (:import
     (org.slf4j LoggerFactory)))
 
 ;; Without this, "lein test NAMESPACE" and :only invocations may fail.


### PR DESCRIPTION
This is part of a series of changes to support nrepl/nrepl in trapperkeeper. It
needs to be merged after the corresponding changes in clj-parent.

This change requires lein 2.9.0 or later to work; this is when the lein project
changed from the legacy org.clojure/tools.nrepl to the supported nrepl/nrepl
line of development.

This release drops support for JDK7, as nrepl/nrepl has a minimum requirement
of JDK8.

Must not be merged until after https://github.com/puppetlabs/clj-parent/pull/167 is merged.