### PR TITLE
(maint) Fix some errors being obscured

### DIFF
--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -177,7 +177,9 @@
           (if (keyword? type)
             (case (without-ns (:type m))
               :cli-error (quit 1 (:message m) *err*)
-              :cli-help (quit 0 (:message m) *out*))))
+              :cli-help (quit 0 (:message m) *out*)
+              ;; By default let the throw below reraise the error
+              nil)))
         (throw+))
       (finally
         (log/debug (i18n/trs "Finished TK main lifecycle, shutting down Clojure agent threads."))


### PR DESCRIPTION
If a slingshot error was thrown with a `:type` value other than `:cli-help` or
`:cli-error`, the original error would be replaced by an error about a missing
clause in the case statement. This allows those errors to just be rethrown.