### PR TITLE
(TK-480) Enable Cider middleware support in the nrepl service

### DIFF
--- a/documentation/Built-in-nREPL-Service.md
+++ b/documentation/Built-in-nREPL-Service.md
@@ -25,12 +25,17 @@ The port that the `nREPL` server is bound to. If no port is defined then the def
 
 A list of nREPL middlewares to load; for example, for compatibility with LightTable or other editors.
 
+## `cider-enabled`
+
+The `cider-enabled` flag is a boolean value, which can be either `"true"` or `"false"`. When this is set to true, the `cider-nrepl` middleware will be injected into the nrepl session. If this value is not specified then `cider-enabled=false` is assumed.
+
 ## Typical `config.conf` for nREPL
 
 ```conf
 nrepl {
    port = 12345
    enabled = true
+   cider-enabled = true
    middlewares = [lighttable.nrepl.handler/lighttable-ops]
 }
 ```

--- a/documentation/Configuring-the-nREPL-Service.md
+++ b/documentation/Configuring-the-nREPL-Service.md
@@ -20,12 +20,17 @@ The port that the `nREPL` server is bound to. If no port is defined then the def
 
 A list of nREPL middlewares to load; for example, for compatibility with LightTable or other editors.
 
+## `cider-enabled`
+
+The `cider-enabled` flag is a boolean value, which can be either `"true"` or `"false"`. When this is set to true, the `cider-nrepl` middleware will be injected into the nrepl session. If this value is not specified then `cider-enabled=false` is assumed.
+
 ## Typical `config.ini` for nREPL
 
 ```ini
 [nrepl]
 port = 12345
 enabled = true
+cider-enabled = true
 middlewares = [lighttable.nrepl.handler/lighttable-ops]
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n]
                  [nrepl/nrepl]
+                 [cider/cider-nrepl "0.21.0"]
                  ]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/src/puppetlabs/trapperkeeper/plugins.clj
+++ b/src/puppetlabs/trapperkeeper/plugins.clj
@@ -19,7 +19,10 @@
    (not (.startsWith name "META-INF"))
 
     ;; lein includes project.clj ... no thank you
-   (not (= name "project.clj"))))
+   (not (= name "project.clj"))
+
+    ;; *data-readers* extensions can exist in multiple projects
+   (not (= name "data_readers.clj"))))
 
 (defn- handle-duplicate!
   "Helper for `process-file`; handles a found duplicate.  Throws an exception

--- a/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/nrepl/nrepl_service_test.clj
@@ -65,3 +65,16 @@
       (is (= "success" (with-open [conn (repl/connect :port 7888)]
                          (:test (first (-> (repl/client conn 1000)
                                            (repl/message {:op "middlewaretest"}))))))))))
+
+(deftest test-nrepl-service
+  (testing "An nREPL service with cider enabled and a test middleware"
+    (with-app-with-config app
+      [nrepl-service]
+      {:nrepl {:port          7888
+               :host          "0.0.0.0"
+               :enabled       "true"
+               :cider-enabled "true"
+               :middlewares    ["puppetlabs.trapperkeeper.services.nrepl.nrepl-test-send-middleware/send-test"]}}
+      (is (= "success" (with-open [conn (repl/connect :port 7888)]
+                         (:test (first (-> (repl/client conn 1000)
+                                           (repl/message {:op "middlewaretest"}))))))))))


### PR DESCRIPTION
Cider has a set of nrepl middlewares which it relies on to provide its full functionality. This adds a new configuration option to the nrepl service (`cider-enabled`) which will inject those middlewares. If that option is disabled, the nrepl service will continue to behave as before.

This also updates the exclusions in duplicate-file detection to handle [custom data readers](https://clojuredocs.org/clojure.core/*data-readers*)