### PR TITLE
(PDB-4636) request-shutdown: support custom exit status/messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+
+# Emacs
+*#
+*~
+.#*
+
 .lein-failures
 .lein-repl-history
 target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,29 @@
 language: clojure
 lein: 2.9.1
-jdk:
-  - openjdk11
-  - openjdk8
+
+jobs:
+  include:
+    - jdk: openjdk8
+      name: lein test (openjdk8)
+    - jdk: openjdk11
+      name: lein test (openjdk11)
+    - jdk: openjdk8
+      name: external tests (openjdk8)
+      script: lein uberjar && ext/test/run-all
+    - jdk: openjdk11
+      name: external tests (openjdk11)
+      script: lein uberjar && ext/test/run-all
+    - name: external tests (openjdk11)
+      # Apparently travis' lein support is broken right now
+      language: java
+      os: osx
+      osx_image: xcode10.3
+      script: |
+        # prep in standalone script so things like set -x don't affect travis
+        ext/travisci/prep-macos \
+        && export PATH="$(pwd)/ext/travisci/bin:$PATH" \
+        && lein uberjar \
+        && ext/test/run-all
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,8 @@ jobs:
 
 notifications:
   email: false
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/Library/Caches/Homebrew

--- a/documentation/Built-in-Shutdown-Service.md
+++ b/documentation/Built-in-Shutdown-Service.md
@@ -54,10 +54,33 @@ To use them, you may simply specify a dependency on them:
 
 ### `request-shutdown`
 
-`request-shutdown` is a no-arg function that will simply cause
-Trapperkeeper to initiate a normal shutdown of the application
-container (which will, in turn, cause all registered shutdown hooks to
-be called).  It is asynchronous.
+`request-shutdown` initiates a shutdown of the application container
+which will, in turn, cause all registered shutdown hooks to be called.
+It is asynchronous and will eventually cause the `run` function to
+return.
+
+It accepts an optional argument which can be used to provide a map
+specifying a process exit status and final messages like this:
+
+```clj
+{:puppetlabs.trapperkepper.core/exit`
+ {:status 3
+  :messages [["Unexpected filesystem error ..." *err*]]}}
+```
+
+which will finally be thrown from `run` as an `ex-info` of `:kind`
+`:puppetlabs.trapperkepper.core/exit` like this:
+
+
+```clj
+{:kind :puppetlabs.trapperkepper.core/exit`
+ :status 3
+ :messages [["Unexpected filesystem error ..." *err*]]}}
+```
+
+The `:messages` should include any desired newlines, and when relying
+on `:puppetlabs.trapperkepper.core/main`, the `:messages` will be
+printed and `exit` will be called with the given `:status`.
 
 ### `shutdown-on-error`
 

--- a/documentation/Built-in-Shutdown-Service.md
+++ b/documentation/Built-in-Shutdown-Service.md
@@ -54,7 +54,10 @@ To use them, you may simply specify a dependency on them:
 
 ### `request-shutdown`
 
-`request-shutdown` is a no-arg function that will simply cause Trapperkeeper to initiate a normal shutdown of the application container (which will, in turn, cause all registered shutdown hooks to be called).  It is asynchronous.
+`request-shutdown` is a no-arg function that will simply cause
+Trapperkeeper to initiate a normal shutdown of the application
+container (which will, in turn, cause all registered shutdown hooks to
+be called).  It is asynchronous.
 
 ### `shutdown-on-error`
 

--- a/documentation/Command-Line-Arguments.md
+++ b/documentation/Command-Line-Arguments.md
@@ -56,6 +56,10 @@ If you don't want to defer to Trapperkeeper as your `:main` namespace, you can s
   (apply trapperkeeper/main args))
 ```
 
+Trapperkeeper's `main` will call `exit` itself in some cases,
+e.g. after argument processing errors, `--help` requests, or calls to
+`request-shutdown` that specify a specific process exit status.
+
 ### Call Trapperkeeper's `run` function directly
 
 If your application needs to handle command line arguments directly, rather than allowing Trapperkeeper to handle them, you can circumvent Trapperkeeper's `main` function and call `run` directly.
@@ -79,6 +83,11 @@ But, if you absolutely must...  Here's how it can be done:
 ```
 
 Note that Trapperkeeper's `run` function requires a map as an argument, and this map must contain the `:config` key which Trapperkeeper will use just as it would have used the `--config` value from the command line.  You may also (optionally) provide `:bootstrap-config` and `:debug` keys, to override the path to the bootstrap configuration file and/or enable debugging on the application.
+
+If shutdown is initiatiated by a call to `request-shutdown` asking for
+a specific exit status, `run` will throw an ex-info exception with a
+`:kind` of `puppetlabs.trapperkeeper.core/exit`.  See the
+`request-shutdown` documentation for additional information.
 
 ### Other Ways to Boot
 

--- a/ext/test/custom-exit-behavior
+++ b/ext/test/custom-exit-behavior
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -uexo pipefail
+
+usage() { echo "Usage: $(basename "$0")"; }
+misuse() { usage 1>&2; exit 2; }
+tk() { lein trampoline run "$@"; }
+
+test $# -eq 0 || misuse
+
+tmpdir="$(mktemp -d "test-top-level-cli-XXXXXX")"
+tmpdir="$(cd "$tmpdir" && pwd)"
+trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+
+rc=0
+tk -d -b ext/test/lib/custom-exit-behavior/bootstrap.cfg \
+   1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+cat "$tmpdir/out" "$tmpdir/err"
+test "$rc" -eq 7
+grep -F 'Some excitement!' "$tmpdir/out"
+grep -F 'More excitement!' "$tmpdir/err"

--- a/ext/test/lib/custom-exit-behavior/bootstrap.cfg
+++ b/ext/test/lib/custom-exit-behavior/bootstrap.cfg
@@ -1,0 +1,1 @@
+puppetlabs.trapperkeeper.custom-exit-behavior-test/custom-exit-behavior-test-service

--- a/ext/test/run-all
+++ b/ext/test/run-all
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -uexo pipefail
+
+usage() { echo "Usage: [TRAPPERKEEPER_JAR=JAR] $(basename "$0")"; }
+misuse() { usage 1>&2; exit 2; }
+
+test $# -eq 0 || misuse
+
+ext/test/top-level-cli

--- a/ext/test/run-all
+++ b/ext/test/run-all
@@ -8,3 +8,4 @@ misuse() { usage 1>&2; exit 2; }
 test $# -eq 0 || misuse
 
 ext/test/top-level-cli
+ext/test/custom-exit-behavior

--- a/ext/test/top-level-cli
+++ b/ext/test/top-level-cli
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -uexo pipefail
+
+usage() { echo "Usage: [TRAPPERKEEPER_JAR=JAR] $(basename "$0")"; }
+misuse() { usage 1>&2; exit 2; }
+
+test $# -eq 0 || misuse
+
+tmpdir="$(mktemp -d "test-top-level-cli-XXXXXX")"
+tmpdir="$(cd "$tmpdir" && pwd)"
+trap "$(printf 'rm -rf %q' "$tmpdir")" EXIT
+
+
+## Test handling an unknown option
+rc=0
+./tk --invalid-option 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+cat "$tmpdir/out" "$tmpdir/err"
+test "$rc" -eq 1
+grep -F 'Unknown option: "--invalid-option"' "$tmpdir/err"
+
+
+## Test --help
+rc=0
+./tk --help  1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+cat "$tmpdir/out" "$tmpdir/err"
+test "$rc" -eq 0
+grep -F 'Path to bootstrap config file' "$tmpdir/out"
+test $(grep -c -F 'Path to bootstrap config file' "$tmpdir/out") -eq 1
+test $(wc -c < "$tmpdir/out") -eq 650
+
+
+## Test handling a missing bootstrap file
+rc=0
+./tk frobnicate ... 1>"$tmpdir/out" 2>"$tmpdir/err" || rc=$?
+cat "$tmpdir/out" "$tmpdir/err"
+test "$rc" -eq 1
+grep -F 'Unable to find bootstrap.cfg file via --bootstrap-config' "$tmpdir/err"

--- a/ext/travisci/prep-macos
+++ b/ext/travisci/prep-macos
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exu
+
+java -version
+
+# Something was wrong with travis' macos lein, so just grab our own
+mkdir -p ext/travisci/bin
+curl -o lein 'https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein'
+chmod +x lein
+mv lein ext/travisci/bin/

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/trapperkeeper "3.0.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper "3.1.0-SNAPSHOT"
   :description "A framework for configuring, composing, and running Clojure services."
 
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/trapperkeeper/core.clj
+++ b/src/puppetlabs/trapperkeeper/core.clj
@@ -173,11 +173,11 @@
           (internal/parse-cli-args!)
           (run))
       (catch map? m
-        (let [type (:type m)]
+        (let [type (:kind m)]
           (if (keyword? type)
-            (case (without-ns (:type m))
-              :cli-error (quit 1 (:message m) *err*)
-              :cli-help (quit 0 (:message m) *out*)
+            (case (without-ns (:kind m))
+              :cli-error (quit 1 (:msg m) *err*)
+              :cli-help (quit 0 (:msg m) *out*)
               ;; By default let the throw below reraise the error
               nil)))
         (throw+))

--- a/test/puppetlabs/trapperkeeper/custom_exit_behavior_test.clj
+++ b/test/puppetlabs/trapperkeeper/custom_exit_behavior_test.clj
@@ -1,0 +1,16 @@
+(ns puppetlabs.trapperkeeper.custom-exit-behavior-test
+  (:require
+   [puppetlabs.trapperkeeper.core :as core]))
+
+(defprotocol CustomExitBehaviorTestService)
+
+(core/defservice custom-exit-behavior-test-service
+  CustomExitBehaviorTestService
+  [[:ShutdownService request-shutdown]]
+  (init [this context] context)
+  (start [this context]
+         (request-shutdown {::core/exit {:messages [["Some excitement!\n" *out*]
+                                                    ["More excitement!\n" *err*]]
+                                         :status 7}})
+         context)
+  (stop [this context] context))

--- a/tk
+++ b/tk
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+jar_glob='trapperkeeper-*-SNAPSHOT-standalone.jar'
+
+if test "${TRAPPERKEEPER_JAR:-}"; then
+    jar="$TRAPPERKEEPER_JAR"
+else
+    # Find the standalone jar and make sure there's only one.
+    # FIXME: minor race here between find runs
+    # Use a bash array expansion to count the files so we don't have
+    # to worry about strange paths (though admittedly unlikely here).
+    shopt -s nullglob
+    jars=(target/$jar_glob)
+    shopt -u nullglob
+    if test "${#jars[@]}" -gt 1; then
+        echo "error: found more than one SNAPSHOT jar:" 1>&2
+        find target -maxdepth 1 -name "$jar_glob" 1>&2
+        exit 2
+    fi
+    jar="${jars[0]}"
+fi
+
+if ! test -e "$jar"; then
+    printf 'Unable to find target/%s; have you run "lein uberjar"?\n' \
+           "$jar" 1>&2
+    exit 2
+fi
+
+exec java -jar "$jar" "$@"


### PR DESCRIPTION
This makes it possible to specify a process exit status value and final messages when calling `request-shutdown`.  The series also fixes some bugs, and adds fully "external" top-level tests.  I needed to make any number of somewhat arbitrary choices, particularly regarding the tests, and mostly leaned toward things previously done in pdb, but I'm happy to rework whatever we like.

You can try all the new tests (which for now just print *everything*, to make CI postmortems easier) by invoking this:
```
lein uberjar
ext/test/run-all
```
from the project directory.

You can also run only the custom exit status tests by invoking `ext/test/custom-exit-status` directly.  And note that particular test, unlike `top-level-cli` doesn't actually rely on the uberjar right now).

Please see the individual commit messages for additional information, and looking at the individual commits might make it easier to become confident in the changes.  I attempted to present the changes step-by-step. 
