### PR TITLE
(maint) Remove pl-clojure-style linter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/pl-clojure-style"]
-	path = ext/pl-clojure-style
-	url = git://github.com/puppetlabs/pl-clojure-style.git

--- a/project.clj
+++ b/project.clj
@@ -50,8 +50,7 @@
                                      :sign-releases false}]]
 
   ;; Convenience for manually testing application shutdown support - run `lein test-external-shutdown`
-  :aliases {"cljfmt" ["with-profile" "+cljfmt" "cljfmt"]
-            "test-external-shutdown" ["trampoline" "run" "-m" "examples.shutdown-app.test-external-shutdown"]}
+  :aliases {"test-external-shutdown" ["trampoline" "run" "-m" "examples.shutdown-app.test-external-shutdown"]}
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
@@ -59,10 +58,7 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
-  :profiles {:cljfmt {:plugins [[lein-cljfmt "0.5.0"]]
-                      :parent-project {:path "ext/pl-clojure-style/project.clj"
-                                       :inherit [:cljfmt]}}
-             :dev {:source-paths ["examples/shutdown_app/src"
+  :profiles {:dev {:source-paths ["examples/shutdown_app/src"
                                   "examples/java_service/src/clj"]
                    :java-source-paths ["examples/java_service/src/java"]
                    :dependencies [[puppetlabs/kitchensink :classifier "test"]]}


### PR DESCRIPTION
This commit removes all references to the pl-clojure-style repo. This was used
for linting / style checking in the past, but hasn't been used for quite some
time, so no reason to keep the `cljfmt` profile for running it.