### PR TITLE
(PE-36476) Replace clj-yaml with snakeyaml 2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
                  [clj-time]
                  [clj-commons/fs]
-                 [clj-commons/clj-yaml]
+                 [org.yaml/snakeyaml "2.0"]
 
                  [prismatic/plumbing]
                  [prismatic/schema]

--- a/src/puppetlabs/trapperkeeper/common.clj
+++ b/src/puppetlabs/trapperkeeper/common.clj
@@ -1,5 +1,7 @@
 (ns puppetlabs.trapperkeeper.common
-  (:require [schema.core :as schema]))
+  (:require [schema.core :as schema])
+  (:import (java.util List Map Set)
+          (org.yaml.snakeyaml Yaml)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Schemas
@@ -11,3 +13,33 @@
               (schema/optional-key :plugins)          schema/Str
               (schema/optional-key :restart-file)     schema/Str
               (schema/optional-key :help)             schema/Bool})
+
+(defprotocol JavaMap->ClojureMap
+  (java->clj [o]))
+
+(extend-protocol JavaMap->ClojureMap
+  Map
+  (java->clj [o] (let [entries (.entrySet o)]
+                   (reduce (fn [m [^String k v]]
+                             (assoc m (keyword k) (java->clj v)))
+                           {} entries)))
+
+  List
+  (java->clj [o] (vec (map java->clj o)))
+
+  Set
+  (java->clj [o] (set (map java->clj o)))
+
+  Object
+  (java->clj [o] o)
+
+  nil
+  (java->clj [_] nil))
+
+(defn parse-yaml
+  [yaml-string]
+  ;; default in snakeyaml 2.0 is to not allow
+  ;; global tags, which is the source of exploits.
+  (let [yaml (new Yaml)
+        data (.load yaml ^String yaml-string)]
+    (java->clj data)))

--- a/src/puppetlabs/trapperkeeper/config.clj
+++ b/src/puppetlabs/trapperkeeper/config.clj
@@ -23,7 +23,6 @@
             [me.raynes.fs :as fs]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.config.typesafe :as typesafe]
-            [clj-yaml.core :as yaml]
             [puppetlabs.trapperkeeper.services :refer [service service-context]]
             [puppetlabs.trapperkeeper.logging :refer [configure-logging!]]
             [clojure.tools.logging :as log]
@@ -58,7 +57,7 @@
     (edn/read (PushbackReader. (io/reader file)))
 
     #{".yaml" ".yml"}
-    (yaml/parse-string (slurp file))
+    (common/parse-yaml (slurp file))
 
     (throw (IllegalArgumentException.
             (i18n/trs "Config file {0} must end in .conf or other recognized extension"


### PR DESCRIPTION
This removes the use of clj-yaml for yaml parsing because internally it uses snakeyaml 1.33. Instead, snakeyaml 2.0 is used directly and a routine for mapping from java structures to clojure structures to clojure structures is added.