### PR TITLE
(maint) Add flexibility to `logged?` to not only match a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+* adds a new arity to `logged?` that removes the restriction that only one log line must match the pattern, adds printing to the function and repo documentation to make users aware of this single line match restriction
+
 ## 4.0.0
 
 This is a major release with breaking changes.

--- a/documentation/Test-Utils.md
+++ b/documentation/Test-Utils.md
@@ -44,10 +44,14 @@ since the beginning of the form.
 See the `logged?` docstring for a complete description, but as an
 example, if the first argument is a regex pattern (typically generated
 via Clojure's `#"pattern"`), then `logged?` will return true if the
-pattern matches the message of anything that has been logged since the
-beginning of the enclosing `with-test-logging` form.  An optional
+pattern matches a single message of anything that has been logged since the
+beginning of the enclosing `with-test-logging` form. An optional
 second parameter restricts the match to log events with the specified
 level: `:trace`, `:debug`, `:info`, `:warn`, `:error` or `:fatal`.
+
+Note: by default `logged?` returns true only if there is exactly one
+log line match. An optional third parameter can be specified to disable
+this restriction.
 
 ### `event->map`
 

--- a/test/puppetlabs/trapperkeeper/logging_test.clj
+++ b/test/puppetlabs/trapperkeeper/logging_test.clj
@@ -37,6 +37,23 @@
         (is (true? @done?))
         (is (logged? #"test thread" :info))))))
 
+(deftest with-test-logging-and-duplicate-log-lines
+  (testing "test-logging captures matches duplicate lines when specified"
+    (with-test-logging
+      (log/error "duplicate message")
+      (log/error "duplicate message")
+      (log/warn "duplicate message")
+      (log/warn "single message")
+      (testing "single line only match"
+        (is (not (logged? #"duplicate message"))) ;; original behavior of the fn, default behavior
+        (is (logged? #"duplicate message" :warn false)))
+      (testing "disabling single line match, enabling multiple line match"
+        (is (logged? #"duplicate message" :error true))
+        (is (logged? #"duplicate message" nil true))
+        (testing "still handles single matches"
+          (is (logged? #"single message" nil true))
+          (is (logged? #"single message" :warn true)))))))
+
 (deftest test-logging-configuration
   (testing "Calling `configure-logging!` with a logback.xml file"
     (tk-logging/configure-logging! "./dev-resources/logging/logback-debug.xml")

--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -321,20 +321,24 @@
            ~@body)))))
 
 (s/defn ^{:always-validate true} logged?
-  ([msg-or-pred] (logged? msg-or-pred nil))
+  ([msg-or-pred] (logged? msg-or-pred nil nil))
+  ([msg-or-pred maybe-level] (logged? msg-or-pred maybe-level nil))
   ([msg-or-pred :- (s/conditional ifn? (s/pred ifn?)
                                   string? s/Str
                                   :else Pattern)
-    maybe-level :- (s/maybe (s/pred #(levels %)))]
+    maybe-level :- (s/maybe (s/pred #(levels %)))
+    disable-single-line-match-restriction :- (s/maybe s/Bool)]
    (let [match? (cond (ifn? msg-or-pred) msg-or-pred
                       (string? msg-or-pred) #(= msg-or-pred (:message %))
                       :else #(re-find msg-or-pred (:message %)))
-         one-element? #(and (seq %) (empty? (rest %)))
+         one-element-if-specified? #(if (and (seq %) (or disable-single-line-match-restriction (empty? (rest %))))
+                                      true
+                                      (println "\n`logged?` warning: multiple log line matches found, but this arity expects only one match, returning false. Found matches: " % "\n"))
          correct-level? #(or (nil? maybe-level) (= maybe-level (:level %)))]
      (->> (map event->map @*test-log-events*)
           (filter correct-level?)
           (filter match?)
-          (one-element?)))))
+          (one-element-if-specified?)))))
 
 (defmethod clojure.test/assert-expr 'logged? [is-msg form]
   ;"Asserts that exactly one event in *test-log-events* has a message
@@ -344,10 +348,10 @@
   ;is specified, the message's keyword level (:info, :error, etc.) must
   ;also match.  For example:
   ;  (with-test-logging (log/info \"123\") (is (logged? #\"2\")))."
-  (assert (#{2 3} (count form)))
-  (let [[_ msg-or-pred level] form]
+  (assert (#{2 3 4} (count form)))
+  (let [[_ msg-or-pred level disable-single-line-restriction] form]
     `(let [events# @@#'puppetlabs.trapperkeeper.testutils.logging/*test-log-events*]
-       (if-not (logged? ~msg-or-pred ~level)
+       (if-not (logged? ~msg-or-pred ~level ~disable-single-line-restriction)
          (clojure.test/do-report
           {:type :fail
            :message ~is-msg


### PR DESCRIPTION
`logged?` previously had an undocumented restriction that it would only return true if a single line matched (more than one would return false). This adds the flexibility to remove this restriction, as some log lines may legitimately be repeated.