### PR TITLE
(maint) update versions of github actions dependencies

### DIFF
--- a/.github/workflows/clojure-linting.yaml
+++ b/.github/workflows/clojure-linting.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: install clj-kondo (this is quite fast)
         run: |
           curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -1,5 +1,8 @@
 name: mend_scan
 on:
+  schedule:
+    # run every day at 4:00am
+    - cron: 0 4 * * *
   workflow_dispatch:
   push:
     branches:
@@ -13,18 +16,18 @@ jobs:
       with:
         service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
     - name: checkout repo content
-      uses: actions/checkout@v2 # checkout the repository content to github runner.
+      uses: actions/checkout@v4 # checkout the repository content to github runner.
       with:
         fetch-depth: 1
     # install java which is required for mend and clojure
     - name: setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 17
     # install clojure tools
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@10.1
+      uses: DeLaGuardo/setup-clojure@12.5
       with:
         # Install just one or all simultaneously
         # The value must indicate a particular version of the tool, or use 'latest'


### PR DESCRIPTION
This updats the actions/checkout to the latest, setup-java to the latest, and setup-clojure to the latest to allow the mend scans to operate correctly