### PR TITLE
(maint) fix logging, prepare for release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.2
+* update `logged?` to not emit an incorrect message when there are no matches, and clean up the output from multiple unexpected matches.
+
 ## 4.0.1
 * adds a new arity to `logged?` that removes the restriction that only one log line must match the pattern, adds printing to the function and repo documentation to make users aware of this single line match restriction
 

--- a/test/puppetlabs/trapperkeeper/testutils/logging.clj
+++ b/test/puppetlabs/trapperkeeper/testutils/logging.clj
@@ -320,6 +320,7 @@
               (swap! destination# conj event#))]
            ~@body)))))
 
+
 (s/defn ^{:always-validate true} logged?
   ([msg-or-pred] (logged? msg-or-pred nil nil))
   ([msg-or-pred maybe-level] (logged? msg-or-pred maybe-level nil))
@@ -331,9 +332,14 @@
    (let [match? (cond (ifn? msg-or-pred) msg-or-pred
                       (string? msg-or-pred) #(= msg-or-pred (:message %))
                       :else #(re-find msg-or-pred (:message %)))
-         one-element-if-specified? #(if (and (seq %) (or disable-single-line-match-restriction (empty? (rest %))))
-                                      true
-                                      (println "\n`logged?` warning: multiple log line matches found, but this arity expects only one match, returning false. Found matches: " % "\n"))
+         one-element-if-specified? (fn [items]
+                                     (if (seq items)
+                                       (if (or disable-single-line-match-restriction (empty? (rest items)))
+                                         true
+                                         (do
+                                           (println "\n`logged?` warning: multiple log line matches found, but this arity expects only one match, returning false. Found matches: \n" (pr-str (map :message items)) "\n")
+                                           false))
+                                       false))
          correct-level? #(or (nil? maybe-level) (= maybe-level (:level %)))]
      (->> (map event->map @*test-log-events*)
           (filter correct-level?)


### PR DESCRIPTION
Update the `logged?` function to only emit messages when there are
multiple statements when they aren't expected, and also clean up
the output to be more useful.